### PR TITLE
Add Beckhoff EtherCAT Boxes

### DIFF
--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/ep_126x30_2km.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/ep_126x30_2km.elmt
@@ -1,0 +1,177 @@
+<definition type="element" link_type="simple" hotspot_x="35" hotspot_y="6" width="70" height="260" version="0.100.1">
+    <uuid uuid="{49415c49-d413-4a72-821d-b96d80982a81}"/>
+    <names>
+        <name lang="de">EPxxxx |1:1| 126,5x30mm | IP20-Stecker</name>
+        <name lang="en">EPxxxx |1:1| 126.5x30mm | IP20 connector</name>
+    </names>
+    <elementInformations>
+        <elementInformation name="designation" show="1">EP2339-0003</elementInformation>
+        <elementInformation name="manufacturer" show="1">Beckhoff</elementInformation>
+    </elementInformations>
+    <informations>Author: Moritz Scholjegerdes</informations>
+    <description>
+        <rect ry="0" x="10" y="168" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="10" y="196" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <line end1="none" end2="none" y1="124" antialias="false" y2="124" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="26" length1="1.5" x2="20" length2="1.5"/>
+        <rect ry="0" x="10" y="189" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="10" y="133" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="10" y="175" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="10" y="91" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <text x="18" y="136" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="Up1"/>
+        <rect ry="7" x="-30" y="-3" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="60" height="253" rx="7"/>
+        <circle x="4.5" y="125" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5"/>
+        <rect ry="0" x="10" y="140" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="10" y="112" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="10" y="161" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="10" y="182" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="2" y="187" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="10" y="147" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="2" y="173" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="4.5" y="189" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="10" y="84" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="2" y="131" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="2" y="159" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="4.5" y="175" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <circle x="4.5" y="41" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5"/>
+        <rect ry="0" x="4.5" y="133" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="10" y="154" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="2" y="180" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="10" y="105" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="2" y="138" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="2" y="145" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="10" y="49" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="4.5" y="140" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="4.5" y="182" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <circle x="-22.4" y="216.6" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.8"/>
+        <rect ry="0" x="4.5" y="161" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="2" y="103" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="4.5" y="147" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="10" y="77" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="2" y="152" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="10" y="98" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="10" y="56" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="4.5" y="154" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="2" y="166" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="10" y="63" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="2" y="89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="4.5" y="168" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="4.5" y="105" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="2" y="47" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="2" y="75" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="4.5" y="91" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="4.5" y="49" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="10" y="70" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="2" y="96" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="2" y="54" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="4.5" y="56" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="2" y="61" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="4.5" y="98" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="4.5" y="77" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="4.5" y="63" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="2" y="68" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="4.5" y="70" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="2" y="82" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="4.5" y="84" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="-2" y="40" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="18" height="84" rx="0"/>
+        <circle x="4.5" y="118" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5"/>
+        <rect ry="0" x="2" y="110" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="4.5" y="112" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <text x="1" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="OUT"/>
+        <circle x="7.9" y="218.9" antialias="false" style="line-style:normal;line-weight:normal;filling:gray;color:black" diameter="12.2"/>
+        <circle x="-21.25" y="217.75" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGraySilver;color:black" diameter="14.5"/>
+        <circle x="-19.3" y="219.7" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGrayDimGray;color:black" diameter="10.6"/>
+        <circle x="5.6" y="216.6" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.8"/>
+        <circle x="14.9" y="221.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-12.9" y="221.7" antialias="false" style="line-style:normal;line-weight:thin;filling:HTMLYellowGold;color:black" diameter="1.8"/>
+        <circle x="-17.9" y="226.6" antialias="false" style="line-style:normal;line-weight:thin;filling:HTMLYellowGold;color:black" diameter="1.8"/>
+        <arc x="-21.61" y="245.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="54.5" width="8" height="8" angle="24.8125"/>
+        <circle x="9.9" y="226.4" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-16.9" y="221.7" antialias="false" style="line-style:normal;line-weight:thin;filling:HTMLYellowGold;color:black" diameter="1.8"/>
+        <circle x="10.9" y="221.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="17.44" y="-1.49" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="11.2"/>
+        <circle x="15.9" y="226.4" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-11.9" y="226.6" antialias="false" style="line-style:normal;line-weight:thin;filling:HTMLYellowGold;color:black" diameter="1.8"/>
+        <line end1="none" end2="none" y1="247.06" antialias="false" y2="248.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-14.78" length1="3" x2="-13.13" length2="3"/>
+        <arc x="-14.3" y="241.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="8" height="8" angle="-45"/>
+        <arc x="-29" y="236" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="0" width="12" height="12" angle="90"/>
+        <rect ry="0" x="-27" y="199" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <line end1="none" end2="none" y1="236" antialias="false" y2="236" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-23" length1="1.5" x2="-30" length2="1.5"/>
+        <circle x="-22.4" y="11.6" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.8"/>
+        <line end1="none" end2="none" y1="243" antialias="false" y2="245.86" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="-17" length2="1.5"/>
+        <arc x="13.61" y="-6.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="234.5" width="8" height="8" angle="24.8125"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="31.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-30" length1="1.5" x2="-21" length2="1.5"/>
+        <line end1="none" end2="none" y1="-0.06" antialias="false" y2="-1.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="14.78" length1="3" x2="13.13" length2="3"/>
+        <circle x="-28.56" y="237.51" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="11.2"/>
+        <arc x="6.3" y="-2.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="-45"/>
+        <circle x="-26" y="240" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="6"/>
+        <circle x="-20.1" y="13.9" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGreenLimeGreen;color:black" diameter="12.2"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="35.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-21" length1="1.5" x2="-17" length2="1.5"/>
+        <circle x="-21.96" y="177.41" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <line end1="none" end2="none" y1="35.5" antialias="false" y2="35.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="17" length2="1.5"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-17" y="233" z="98" rotation="0" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{4716c2f4-3f3a-441c-93c8-f90e91168538}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
+            <text>EP2339-0003</text>
+            <info_name>designation</info_name>
+        </dynamic_text>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="31.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="30" length1="1.5" x2="21" length2="1.5"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="195.4" z="100" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <circle x="-21.96" y="185.41" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="35.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="21" length1="1.5" x2="17" length2="1.5"/>
+        <circle x="-13.1" y="16.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-18.1" y="21.4" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-17.1" y="16.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="7.9" y="13.9" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGreenLimeGreen;color:black" diameter="12.2"/>
+        <circle x="-12.1" y="21.4" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="5.6" y="11.6" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.8"/>
+        <circle x="14.9" y="16.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="9.9" y="21.4" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="10.9" y="16.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="15.9" y="21.4" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <line end1="none" end2="none" y1="135.51" antialias="false" y2="135.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.71" length1="3" x2="30.04" length2="3"/>
+        <arc x="-21.61" y="-6.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="8" height="8" angle="45"/>
+        <line end1="none" end2="none" y1="-0.06" antialias="false" y2="-1.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-14.78" length1="3" x2="-13.13" length2="3"/>
+        <arc x="13.7" y="246.11" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
+        <circle x="2" y="9.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-2.5" y="26.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-7" y="9.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <line end1="none" end2="none" y1="133.71" antialias="false" y2="133.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="29.71" length2="3"/>
+        <arc x="-14.3" y="-2.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="216" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-30" length1="1.5" x2="-21" length2="1.5"/>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-21" length1="1.5" x2="-17" length2="1.5"/>
+        <line end1="none" end2="none" y1="212" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="216" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="30" length1="1.5" x2="21" length2="1.5"/>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="21" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="247.63" antialias="false" y2="249.63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="14.53" length1="3" x2="12.53" length2="3"/>
+        <line end1="none" end2="none" y1="246.13" antialias="false" y2="246.11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="28.94" length1="3" x2="18.51" length2="3"/>
+        <line end1="none" end2="none" y1="1.11" antialias="false" y2="1.11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.14" length1="3" x2="-17.61" length2="3"/>
+        <circle x="20" y="1" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="6"/>
+        <arc x="17" y="-1" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="180" width="12" height="12" angle="90"/>
+        <line end1="none" end2="none" y1="11" antialias="false" y2="11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="23" length1="1.5" x2="30" length2="1.5"/>
+        <line end1="none" end2="none" y1="4" antialias="false" y2="1.14" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="17" length1="1.5" x2="17" length2="1.5"/>
+        <text x="-13" y="247" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="BECKHOFF"/>
+        <text x="-13" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
+        <rect ry="0" x="-2" y="124" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="18" height="84" rx="0"/>
+        <circle x="4.5" y="202" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5"/>
+        <rect ry="0" x="2" y="194" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-30" y="-30" z="141" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
+            <text></text>
+            <info_name>label</info_name>
+        </dynamic_text>
+        <rect ry="0" x="4.5" y="196" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <text x="18" y="52" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="Up1"/>
+        <line end1="none" end2="none" y1="124" antialias="false" y2="124" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-11" length1="1.5" x2="-25" length2="1.5"/>
+        <dynamic_text frame="false" Halignment="AlignRight" x="-30" y="64" z="147" rotation="270" font="Liberation Sans,7,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{01f2e6c3-3612-4601-89fd-8a5cd8c0eedf}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>DIO</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignRight" x="-30" y="149" z="147" rotation="270" font="Liberation Sans,7,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{01f2e6c3-3612-4601-89fd-8a5cd8c0eedf}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>DIO</text>
+        </dynamic_text>
+        <terminal type="Generic" x="20" y="225" name="X61" uuid="{abccdad0-3c05-4838-874c-77a77b3b084a}" orientation="e"/>
+        <terminal type="Generic" x="-20" y="20" name="X40" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
+        <terminal type="Generic" x="20" y="20" name="X41" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+        <terminal type="Generic" x="-20" y="225" name="X60" uuid="{d6b16f7c-30d4-436e-a507-9ce7f57228b2}" orientation="w"/>
+        <terminal type="Generic" x="20" y="82" name="" uuid="{69b6ffe9-4a38-48a4-8d1f-f893a80fa7a6}" orientation="e"/>
+        <terminal type="Generic" x="20" y="166" name="" uuid="{57954029-4dd8-4159-8cd6-8848e5c4c9ca}" orientation="e"/>
+    </description>
+</definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/ep_126x30_2km_2x.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/ep_126x30_2km_2x.elmt
@@ -1,0 +1,178 @@
+<definition type="element" link_type="simple" hotspot_x="65" hotspot_y="8" width="130" height="510" version="0.100.1">
+    <uuid uuid="{e3e8e57d-e2a9-4abe-aaec-5cfc4f66c7a0}"/>
+    <names>
+        <name lang="de">EPxxxx |2:1| 126,5x30mm | IP20-Stecker</name>
+        <name lang="en">EPxxxx |2:1| 126.5x30mm | IP20 connector</name>
+    </names>
+    <elementInformations>
+        <elementInformation name="designation" show="1">EP2339-0003</elementInformation>
+        <elementInformation name="manufacturer" show="1">Beckhoff</elementInformation>
+    </elementInformations>
+    <informations>Author: Moritz Scholjegerdes</informations>
+    <description>
+        <rect ry="14" x="-60" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="120" height="506" rx="14"/>
+        <rect ry="0" x="20.7" y="336.47" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="20.7" y="392.28" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <line end1="none" end2="none" y1="248.79" antialias="false" y2="248.79" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="51.78" length1="1.5" x2="40.13" length2="1.5"/>
+        <rect ry="0" x="20.7" y="378.32" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="20.7" y="266.72" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="20.7" y="350.42" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="20.7" y="183.02" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <text x="36.24" y="269.7" font="Liberation Sans,6,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="Up1"/>
+        <ellipse x="10.02" y="250.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="9.71" height="9.96"/>
+        <rect ry="0" x="20.7" y="280.67" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="20.7" y="224.87" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="20.7" y="322.52" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="20.7" y="364.37" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <circle x="15.8" y="27.8" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGreenLimeGreen;color:black" diameter="24.4"/>
+        <rect ry="0" x="5.16" y="374.34" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="20.7" y="294.62" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <circle x="-46" y="370" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <rect ry="0" x="5.16" y="346.44" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="10.02" y="378.32" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="20.7" y="169.07" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="5.16" y="262.74" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="5.16" y="318.54" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="10.02" y="350.42" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <ellipse x="10.02" y="83.37" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="9.71" height="9.96"/>
+        <rect ry="0" x="10.02" y="266.72" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="20.7" y="308.57" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="5.16" y="360.39" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="20.7" y="210.92" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="5.16" y="276.69" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="5.16" y="290.64" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="20.7" y="99.32" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="10.02" y="280.67" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="10.02" y="364.37" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="10.02" y="322.52" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="5.16" y="206.93" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="10.02" y="294.62" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <circle x="-43" y="435" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGraySilver;color:black" diameter="30"/>
+        <rect ry="0" x="20.7" y="155.12" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="5.16" y="304.59" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="20.7" y="196.97" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="20.7" y="113.27" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="10.02" y="308.57" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="5.16" y="332.49" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <circle x="15.8" y="437.8" antialias="false" style="line-style:normal;line-weight:normal;filling:gray;color:black" diameter="24.4"/>
+        <rect ry="0" x="20.7" y="127.22" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="5.16" y="179.03" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="10.02" y="336.47" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="10.02" y="210.92" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="5.16" y="95.33" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="5.16" y="151.13" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <circle x="29.8" y="32.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <rect ry="0" x="10.02" y="183.02" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="10.02" y="99.32" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="20.7" y="141.17" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="5.16" y="192.98" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <circle x="29.8" y="442.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <rect ry="0" x="5.16" y="109.28" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="10.02" y="113.27" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="5.16" y="123.23" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="10.02" y="196.97" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="10.02" y="155.12" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <text x="2" y="13" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="OUT"/>
+        <rect ry="0" x="10.02" y="127.22" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="5.16" y="137.18" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="10.02" y="141.17" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="5.16" y="165.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="10.02" y="169.07" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <circle x="19.8" y="452.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <rect ry="0" x="-2.61" y="81.38" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="34.97" height="167.4" rx="0"/>
+        <circle x="19.8" y="42.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <ellipse x="10.02" y="236.83" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="9.71" height="9.96"/>
+        <rect ry="0" x="5.16" y="220.88" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <arc x="-43.22" y="492.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="51.4375" width="16" height="16" angle="28.5"/>
+        <rect ry="0" x="10.02" y="224.87" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <circle x="21.8" y="442.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="21.8" y="32.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="31.8" y="42.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <rect ry="0" x="-2.61" y="248.79" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="34.97" height="167.4" rx="0"/>
+        <circle x="34.88" y="-3" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="22.4"/>
+        <circle x="31.8" y="452.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <ellipse x="10.02" y="404.23" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="9.71" height="9.96"/>
+        <circle x="-44.8" y="433.2" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
+        <rect ry="0" x="5.16" y="388.29" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-34" y="474.3" z="85" rotation="0" font="Liberation Sans,8,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{b5ec55a8-7f78-1b91-4ada-ed2333c17cda}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
+            <text>EP2339-0003</text>
+            <info_name>designation</info_name>
+        </dynamic_text>
+        <rect ry="0" x="10.02" y="392.28" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <text x="36.24" y="102.3" font="Liberation Sans,6,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="Up1"/>
+        <line end1="none" end2="none" y1="248.79" antialias="false" y2="248.79" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-20.09" length1="1.5" x2="-47.29" length2="1.5"/>
+        <circle x="-40" y="438" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGrayDimGray;color:black" diameter="24"/>
+        <circle x="-25.75" y="443.25" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLYellowGold;color:black" diameter="3.5"/>
+        <circle x="-35.75" y="453.25" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLYellowGold;color:black" diameter="3.5"/>
+        <line end1="none" end2="none" y1="494.42" antialias="false" y2="497.74" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.56" length1="6" x2="-26.26" length2="6"/>
+        <circle x="-33.75" y="443.25" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLYellowGold;color:black" diameter="3.5"/>
+        <circle x="-23.75" y="453.25" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLYellowGold;color:black" diameter="3.5"/>
+        <circle x="11.2" y="433.2" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
+        <arc x="-28.6" y="484.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="225" width="16" height="16" angle="45"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="394.5" z="96" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <arc x="-58" y="472.3" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="0" width="24" height="24" angle="90"/>
+        <rect ry="0" x="-54" y="396" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <line end1="none" end2="none" y1="472.3" antialias="false" y2="472.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-46" length1="3" x2="-60" length2="3"/>
+        <circle x="-44.8" y="23.2" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
+        <line end1="none" end2="none" y1="485.04" antialias="false" y2="492.02" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="-34" length2="3"/>
+        <arc x="27.22" y="-13.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="231.25" width="16" height="16" angle="28.6875"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-60" length1="3" x2="-42" length2="3"/>
+        <line end1="none" end2="none" y1="-0.12" antialias="false" y2="-3.44" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="29.56" length1="6" x2="26.26" length2="6"/>
+        <circle x="-57.12" y="475.3" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="22.4"/>
+        <arc x="12.6" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="45" width="16" height="16" angle="45"/>
+        <circle x="-52" y="480.3" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="12"/>
+        <circle x="-40.2" y="27.8" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGreenLimeGreen;color:black" diameter="24.4"/>
+        <circle x="-46" y="348" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="71" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-42" length1="3" x2="-34" length2="3"/>
+        <line end1="none" end2="none" y1="71" antialias="false" y2="71" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="60" length1="3" x2="42" length2="3"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="71" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="42" length1="3" x2="34" length2="3"/>
+        <circle x="-26.2" y="32.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-36.2" y="42.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-34.2" y="32.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-24.2" y="42.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="11.2" y="23.2" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
+        <line end1="none" end2="none" y1="271" antialias="false" y2="326.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="60.08" length2="6"/>
+        <line end1="none" end2="none" y1="271" antialias="false" y2="271" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="59.42" length1="6" x2="60.08" length2="6"/>
+        <arc x="-43.22" y="-13.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="16" height="16" angle="45"/>
+        <line end1="none" end2="none" y1="-0.12" antialias="false" y2="-3.44" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.56" length1="6" x2="-26.26" length2="6"/>
+        <arc x="27.4" y="492.52" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="16" height="16" angle="45"/>
+        <circle x="4" y="17.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-5" y="53.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-14" y="17.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <line end1="none" end2="none" y1="267.42" antialias="false" y2="267.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="59.42" length2="6"/>
+        <arc x="-28.6" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="16" height="16" angle="45"/>
+        <line end1="none" end2="none" y1="432.3" antialias="false" y2="432.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-60" length1="3" x2="-42" length2="3"/>
+        <line end1="none" end2="none" y1="432.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-42" length1="3" x2="-34" length2="3"/>
+        <line end1="none" end2="none" y1="424.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="432.3" antialias="false" y2="432.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="60" length1="3" x2="42" length2="3"/>
+        <line end1="none" end2="none" y1="432.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="42" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="495.56" antialias="false" y2="499.56" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="29.06" length1="6" x2="25.06" length2="6"/>
+        <line end1="none" end2="none" y1="492.56" antialias="false" y2="492.53" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="57.88" length1="6" x2="36.02" length2="6"/>
+        <line end1="none" end2="none" y1="2.22" antialias="false" y2="2.22" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-58.28" length1="6" x2="-35.22" length2="6"/>
+        <circle x="40" y="2" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="12"/>
+        <arc x="34" y="-2" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="180" width="24" height="24" angle="90"/>
+        <line end1="none" end2="none" y1="22" antialias="false" y2="22" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="46" length1="3" x2="60" length2="3"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-49" y="-36" z="141" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
+            <text></text>
+            <info_name>label</info_name>
+        </dynamic_text>
+        <line end1="none" end2="none" y1="9" antialias="false" y2="2.28" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="34" length1="3" x2="34" length2="3"/>
+        <text x="-25" y="497.3" font="Liberation Sans,7,-1,5,75,0,0,0,0,0,Bold" rotation="0" color="#000000" text="BECKHOFF"/>
+        <text x="-26" y="13" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
+        <dynamic_text frame="false" Halignment="AlignRight" x="-50.5" y="286.61" z="147" rotation="270" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{01f2e6c3-3612-4601-89fd-8a5cd8c0eedf}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>DIO</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignRight" x="-50.5" y="117.21" z="147" rotation="270" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{01f2e6c3-3612-4601-89fd-8a5cd8c0eedf}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>DIO</text>
+        </dynamic_text>
+        <terminal type="Generic" x="-40" y="450" name="X60" uuid="{7d2effee-f301-4f55-ad88-0eb43564e57b}" orientation="w"/>
+        <terminal type="Generic" x="-40" y="40" name="X40" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
+        <terminal type="Generic" x="40" y="450" name="X61" uuid="{c42bc02a-56a4-4d65-ad62-f6cdc62649ce}" orientation="e"/>
+        <terminal type="Generic" x="40" y="40" name="X41" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+        <terminal type="Generic" x="37.12" y="332.49" name="" uuid="{9c809965-24da-4b84-b100-cb24509657c6}" orientation="e"/>
+        <terminal type="Generic" x="37.12" y="165.08" name="" uuid="{777aa446-92b9-412a-80ee-1031ad825ee3}" orientation="e"/>
+    </description>
+</definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/ep_126x30_4xm12a-5.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/ep_126x30_4xm12a-5.elmt
@@ -1,0 +1,187 @@
+<definition type="element" link_type="simple" hotspot_x="35" hotspot_y="6" width="70" height="260" version="0.100.1">
+    <uuid uuid="{1ae4b86e-524c-43a1-b367-10ad34372bd6}"/>
+    <names>
+        <name lang="de">EPxxxx |1:1| 126,5x30mm | 4x M12-Buchse, 5-polig, A-kodiert</name>
+        <name lang="en">EPxxxx |1:1| 126.5x30mm | 4x M12-socket, 5-pol, a-coded</name>
+    </names>
+    <elementInformations>
+        <elementInformation name="designation" show="1">EP1008-0002</elementInformation>
+        <elementInformation name="manufacturer" show="1">Beckhoff</elementInformation>
+    </elementInformations>
+    <informations>Author: Moritz Scholjegerdes</informations>
+    <description>
+        <text x="20" y="76" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="1"/>
+        <text x="20" y="116" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="6"/>
+        <text x="20" y="156" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="5"/>
+        <text x="20" y="196" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="7"/>
+        <circle x="-13.96" y="97.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-22.4" y="216.6" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.8"/>
+        <circle x="12.4" y="133.7" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="12.4" y="173.7" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="12.4" y="93.7" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="12.4" y="53.7" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="10.9" y="138.9" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="10.9" y="98.9" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="10.9" y="178.9" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="10.9" y="58.9" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="9.2" y="184.1" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="9.2" y="104.1" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="9.2" y="144.1" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="9.2" y="64.1" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="5.6" y="177.6" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="5.6" y="97.6" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="5.6" y="137.6" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-13.96" y="137.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="16.1" y="180.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="16.1" y="100.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="16.1" y="140.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="3" y="91" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="18"/>
+        <circle x="3" y="131" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="18"/>
+        <circle x="-13.96" y="177.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="3" y="171" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="18"/>
+        <circle x="-0.5" y="127.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="25"/>
+        <circle x="-0.5" y="87.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="25"/>
+        <circle x="5.6" y="57.6" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-0.5" y="167.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="25"/>
+        <polygon y1="143.65" antialias="false" y2="141.79" y3="143.1" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="3.89" y4="145.11" x2="6.98" x3="7.76" x4="4.72"/>
+        <polygon y1="103.65" antialias="false" y2="101.79" y3="103.1" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="3.89" y4="105.11" x2="6.98" x3="7.76" x4="4.72"/>
+        <polygon y1="183.65" antialias="false" y2="181.79" y3="183.1" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="3.89" y4="185.11" x2="6.98" x3="7.76" x4="4.72"/>
+        <circle x="16.1" y="60.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <text x="0" y="116" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="2"/>
+        <text x="0" y="156" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="4"/>
+        <text x="0" y="196" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="6"/>
+        <text x="1" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="OUT"/>
+        <circle x="-24.5" y="97.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-24.5" y="137.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-24.5" y="177.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="7.9" y="218.9" antialias="false" style="line-style:normal;line-weight:normal;filling:gray;color:black" diameter="12.2"/>
+        <circle x="-21.25" y="217.75" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGraySilver;color:black" diameter="14.5"/>
+        <circle x="-19.3" y="219.7" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGrayDimGray;color:black" diameter="10.6"/>
+        <circle x="5.6" y="216.6" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.8"/>
+        <rect ry="0" x="-27" y="65" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <circle x="14.9" y="221.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-12.9" y="221.7" antialias="false" style="line-style:normal;line-weight:thin;filling:HTMLYellowGold;color:black" diameter="1.8"/>
+        <rect ry="0" x="-27" y="85" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <circle x="-17.9" y="226.6" antialias="false" style="line-style:normal;line-weight:thin;filling:HTMLYellowGold;color:black" diameter="1.8"/>
+        <arc x="-21.61" y="245.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="54.5" width="8" height="8" angle="24.8125"/>
+        <circle x="9.9" y="226.4" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-16.9" y="221.7" antialias="false" style="line-style:normal;line-weight:thin;filling:HTMLYellowGold;color:black" diameter="1.8"/>
+        <circle x="10.9" y="221.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="17.44" y="-1.49" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="11.2"/>
+        <rect ry="0" x="-27" y="105" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <circle x="15.9" y="226.4" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-11.9" y="226.6" antialias="false" style="line-style:normal;line-weight:thin;filling:HTMLYellowGold;color:black" diameter="1.8"/>
+        <rect ry="0" x="-27" y="145" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <line end1="none" end2="none" y1="247.06" antialias="false" y2="248.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-14.78" length1="3" x2="-13.13" length2="3"/>
+        <arc x="-14.3" y="241.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="8" height="8" angle="-45"/>
+        <rect ry="0" x="-27" y="165" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <rect ry="0" x="-27" y="185" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <arc x="-29" y="236" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="0" width="12" height="12" angle="90"/>
+        <rect ry="0" x="-27" y="199" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <line end1="none" end2="none" y1="236" antialias="false" y2="236" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-23" length1="1.5" x2="-30" length2="1.5"/>
+        <circle x="3" y="51" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="18"/>
+        <circle x="-22.4" y="11.6" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.8"/>
+        <line end1="none" end2="none" y1="243" antialias="false" y2="245.86" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="-17" length2="1.5"/>
+        <circle x="-0.5" y="47.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="25"/>
+        <arc x="13.61" y="-6.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="234.5" width="8" height="8" angle="24.8125"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="31.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-30" length1="1.5" x2="-21" length2="1.5"/>
+        <line end1="none" end2="none" y1="-0.06" antialias="false" y2="-1.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="14.78" length1="3" x2="13.13" length2="3"/>
+        <circle x="-28.56" y="237.51" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="11.2"/>
+        <arc x="6.3" y="-2.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="-45"/>
+        <circle x="-26" y="240" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="6"/>
+        <circle x="-20.1" y="13.9" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGreenLimeGreen;color:black" diameter="12.2"/>
+        <circle x="-13.96" y="57.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-24.5" y="57.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="35.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-21" length1="1.5" x2="-17" length2="1.5"/>
+        <rect ry="0" x="-27" y="45" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <circle x="16.04" y="203.41" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <line end1="none" end2="none" y1="35.5" antialias="false" y2="35.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="31.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="30" length1="1.5" x2="21" length2="1.5"/>
+        <circle x="7.04" y="203.41" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="35.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="21" length1="1.5" x2="17" length2="1.5"/>
+        <circle x="-13.1" y="16.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-18.1" y="21.4" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-17.1" y="16.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="7.9" y="13.9" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGreenLimeGreen;color:black" diameter="12.2"/>
+        <circle x="-12.1" y="21.4" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="5.6" y="11.6" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.8"/>
+        <circle x="14.9" y="16.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-17" y="233" z="97" rotation="0" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{4716c2f4-3f3a-441c-93c8-f90e91168538}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
+            <text>EP1008-0002</text>
+            <info_name>designation</info_name>
+        </dynamic_text>
+        <circle x="9.9" y="21.4" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="195.4" z="98" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="181.4" z="98" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21.04" y="61.5" z="99" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21.04" y="141.5" z="100" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <circle x="10.9" y="16.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="121.5" z="101" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="81.5" z="102" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="161.5" z="103" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <circle x="15.9" y="21.4" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="41.5" z="104" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="101.4" z="105" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <line end1="none" end2="none" y1="30.71" antialias="false" y2="3.11" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.96" length1="3" x2="-29.96" length2="3"/>
+        <line end1="none" end2="none" y1="133.71" antialias="false" y2="32.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.96" length1="3" x2="-29.96" length2="3"/>
+        <line end1="none" end2="none" y1="135.51" antialias="false" y2="163.11" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="30.04" length2="3"/>
+        <line end1="none" end2="none" y1="32.51" antialias="false" y2="133.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="30.04" length2="3"/>
+        <line end1="none" end2="none" y1="135.51" antialias="false" y2="135.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.71" length1="3" x2="30.04" length2="3"/>
+        <arc x="-21.61" y="-6.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="8" height="8" angle="45"/>
+        <line end1="none" end2="none" y1="-0.06" antialias="false" y2="-1.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-14.78" length1="3" x2="-13.13" length2="3"/>
+        <arc x="13.7" y="246.11" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
+        <circle x="2" y="9.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-2.5" y="26.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-7" y="9.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <line end1="none" end2="none" y1="133.71" antialias="false" y2="133.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="29.71" length2="3"/>
+        <arc x="-14.3" y="-2.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
+        <rect ry="7" x="-30" y="-3" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="60" height="253" rx="7"/>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="216" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-30" length1="1.5" x2="-21" length2="1.5"/>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-21" length1="1.5" x2="-17" length2="1.5"/>
+        <line end1="none" end2="none" y1="212" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="216" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="30" length1="1.5" x2="21" length2="1.5"/>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="21" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="247.63" antialias="false" y2="249.63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="14.53" length1="3" x2="12.53" length2="3"/>
+        <line end1="none" end2="none" y1="246.13" antialias="false" y2="246.11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="28.94" length1="3" x2="18.51" length2="3"/>
+        <line end1="none" end2="none" y1="1.11" antialias="false" y2="1.11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.14" length1="3" x2="-17.61" length2="3"/>
+        <circle x="20" y="1" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="6"/>
+        <rect ry="0" x="-27" y="125" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <arc x="17" y="-1" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="180" width="12" height="12" angle="90"/>
+        <line end1="none" end2="none" y1="11" antialias="false" y2="11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="23" length1="1.5" x2="30" length2="1.5"/>
+        <line end1="none" end2="none" y1="4" antialias="false" y2="1.14" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="17" length1="1.5" x2="17" length2="1.5"/>
+        <text x="-13" y="247" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="BECKHOFF"/>
+        <text x="-13" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
+        <polygon y1="63.65" antialias="false" y2="61.79" y3="63.1" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="3.89" y4="65.11" x2="6.98" x3="7.76" x4="4.72"/>
+        <text x="0" y="76" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="0"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-30" y="-30" z="141" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
+            <text></text>
+            <info_name>label</info_name>
+        </dynamic_text>
+        <terminal type="Generic" x="20" y="60" name="X01" uuid="{c905d889-7b5a-4d9e-8e4e-2770b5067a5f}" orientation="e"/>
+        <terminal type="Generic" x="20" y="20" name="X41" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+        <terminal type="Generic" x="-20" y="225" name="X60" uuid="{d6b16f7c-30d4-436e-a507-9ce7f57228b2}" orientation="w"/>
+        <terminal type="Generic" x="20" y="180" name="X04" uuid="{5ed505f8-b8f7-42de-98db-d2b9f6c9c6bc}" orientation="e"/>
+        <terminal type="Generic" x="20" y="100" name="X02" uuid="{ee1b0a90-35db-4c4c-b4bd-5699eccdb43a}" orientation="e"/>
+        <terminal type="Generic" x="20" y="140" name="X03" uuid="{ba421d53-0a59-489c-a38f-c31a98bdf882}" orientation="e"/>
+        <terminal type="Generic" x="20" y="225" name="X61" uuid="{abccdad0-3c05-4838-874c-77a77b3b084a}" orientation="e"/>
+        <terminal type="Generic" x="-20" y="20" name="X40" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
+    </description>
+</definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/ep_126x30_4xm12a-5.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/ep_126x30_4xm12a-5.elmt
@@ -1,5 +1,5 @@
 <definition type="element" link_type="simple" hotspot_x="35" hotspot_y="6" width="70" height="260" version="0.100.1">
-    <uuid uuid="{1ae4b86e-524c-43a1-b367-10ad34372bd6}"/>
+    <uuid uuid="{b45b4867-b770-48f7-a60b-bdc78af42962}"/>
     <names>
         <name lang="de">EPxxxx |1:1| 126,5x30mm | 4x M12-Buchse, 5-polig, A-kodiert</name>
         <name lang="en">EPxxxx |1:1| 126.5x30mm | 4x M12-socket, 5-pol, a-coded</name>
@@ -10,6 +10,7 @@
     </elementInformations>
     <informations>Author: Moritz Scholjegerdes</informations>
     <description>
+        <rect ry="7" x="-30" y="-3" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="60" height="253" rx="7"/>
         <text x="20" y="76" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="1"/>
         <text x="20" y="116" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="6"/>
         <text x="20" y="156" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="5"/>
@@ -106,44 +107,40 @@
         <circle x="-12.1" y="21.4" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
         <circle x="5.6" y="11.6" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.8"/>
         <circle x="14.9" y="16.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
-        <dynamic_text frame="false" Halignment="AlignLeft" x="-17" y="233" z="97" rotation="0" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{4716c2f4-3f3a-441c-93c8-f90e91168538}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-17" y="233" z="98" rotation="0" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{4716c2f4-3f3a-441c-93c8-f90e91168538}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
             <text>EP1008-0002</text>
             <info_name>designation</info_name>
         </dynamic_text>
         <circle x="9.9" y="21.4" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="195.4" z="98" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="195.4" z="100" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text></text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="181.4" z="98" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="181.4" z="101" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text></text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21.04" y="61.5" z="99" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21.04" y="61.5" z="102" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text></text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21.04" y="141.5" z="100" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21.04" y="141.5" z="103" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="121.5" z="104" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="81.5" z="105" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text></text>
         </dynamic_text>
         <circle x="10.9" y="16.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="121.5" z="101" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="161.5" z="107" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text></text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="81.5" z="102" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="41.5" z="108" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text></text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="161.5" z="103" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="101.4" z="109" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text></text>
         </dynamic_text>
         <circle x="15.9" y="21.4" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="41.5" z="104" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text></text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="101.4" z="105" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text></text>
-        </dynamic_text>
-        <line end1="none" end2="none" y1="30.71" antialias="false" y2="3.11" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.96" length1="3" x2="-29.96" length2="3"/>
-        <line end1="none" end2="none" y1="133.71" antialias="false" y2="32.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.96" length1="3" x2="-29.96" length2="3"/>
-        <line end1="none" end2="none" y1="135.51" antialias="false" y2="163.11" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="30.04" length2="3"/>
-        <line end1="none" end2="none" y1="32.51" antialias="false" y2="133.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="30.04" length2="3"/>
         <line end1="none" end2="none" y1="135.51" antialias="false" y2="135.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.71" length1="3" x2="30.04" length2="3"/>
         <arc x="-21.61" y="-6.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="8" height="8" angle="45"/>
         <line end1="none" end2="none" y1="-0.06" antialias="false" y2="-1.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-14.78" length1="3" x2="-13.13" length2="3"/>
@@ -153,7 +150,6 @@
         <circle x="-7" y="9.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
         <line end1="none" end2="none" y1="133.71" antialias="false" y2="133.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="29.71" length2="3"/>
         <arc x="-14.3" y="-2.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
-        <rect ry="7" x="-30" y="-3" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="60" height="253" rx="7"/>
         <line end1="none" end2="none" y1="216" antialias="false" y2="216" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-30" length1="1.5" x2="-21" length2="1.5"/>
         <line end1="none" end2="none" y1="216" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-21" length1="1.5" x2="-17" length2="1.5"/>
         <line end1="none" end2="none" y1="212" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="17" length2="1.5"/>
@@ -175,13 +171,13 @@
             <text></text>
             <info_name>label</info_name>
         </dynamic_text>
-        <terminal type="Generic" x="20" y="60" name="X01" uuid="{c905d889-7b5a-4d9e-8e4e-2770b5067a5f}" orientation="e"/>
-        <terminal type="Generic" x="20" y="20" name="X41" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
         <terminal type="Generic" x="-20" y="225" name="X60" uuid="{d6b16f7c-30d4-436e-a507-9ce7f57228b2}" orientation="w"/>
-        <terminal type="Generic" x="20" y="180" name="X04" uuid="{5ed505f8-b8f7-42de-98db-d2b9f6c9c6bc}" orientation="e"/>
-        <terminal type="Generic" x="20" y="100" name="X02" uuid="{ee1b0a90-35db-4c4c-b4bd-5699eccdb43a}" orientation="e"/>
         <terminal type="Generic" x="20" y="140" name="X03" uuid="{ba421d53-0a59-489c-a38f-c31a98bdf882}" orientation="e"/>
-        <terminal type="Generic" x="20" y="225" name="X61" uuid="{abccdad0-3c05-4838-874c-77a77b3b084a}" orientation="e"/>
+        <terminal type="Generic" x="20" y="20" name="X41" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+        <terminal type="Generic" x="20" y="180" name="X04" uuid="{5ed505f8-b8f7-42de-98db-d2b9f6c9c6bc}" orientation="e"/>
         <terminal type="Generic" x="-20" y="20" name="X40" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
+        <terminal type="Generic" x="20" y="100" name="X02" uuid="{ee1b0a90-35db-4c4c-b4bd-5699eccdb43a}" orientation="e"/>
+        <terminal type="Generic" x="20" y="225" name="X61" uuid="{abccdad0-3c05-4838-874c-77a77b3b084a}" orientation="e"/>
+        <terminal type="Generic" x="20" y="60" name="X01" uuid="{c905d889-7b5a-4d9e-8e4e-2770b5067a5f}" orientation="e"/>
     </description>
 </definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/ep_126x30_4xm12a-5_twinsafe.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/ep_126x30_4xm12a-5_twinsafe.elmt
@@ -1,0 +1,193 @@
+<definition type="element" link_type="simple" hotspot_x="35" hotspot_y="6" width="70" height="260" version="0.100.1">
+    <uuid uuid="{573d7d7e-ba8b-41e2-b9c1-c55f4197cfc3}"/>
+    <names>
+        <name lang="de">EP19xx |1:1| 126,5x30mm | 4x M12-Buchse, 5-polig, A-kodiert</name>
+        <name lang="en">EP19xx |1:1| 126.5x30mm | 4x M12-socket, 5-pol, a-coded</name>
+    </names>
+    <elementInformations>
+        <elementInformation name="designation" show="1">EP1918-0002</elementInformation>
+        <elementInformation name="manufacturer" show="1">Beckhoff</elementInformation>
+    </elementInformations>
+    <informations>Author: Moritz Scholjegerdes</informations>
+    <description>
+        <rect ry="7" x="-30" y="-3" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLYellowGold;color:black" width="60" height="253" rx="7"/>
+        <line end1="none" end2="none" y1="245.1" antialias="false" y2="245.1" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="11.5" length1="1.5" x2="10.5" length2="1.5"/>
+        <line end1="none" end2="none" y1="243" antialias="false" y2="243" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="13" length1="1.5" x2="9" length2="1.5"/>
+        <line end1="none" end2="none" y1="243.9" antialias="false" y2="243.9" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="12.6" length1="1.5" x2="9.6" length2="1.5"/>
+        <rect ry="0" x="-27" y="65" antialias="false" style="line-style:normal;line-weight:thin;filling:white;color:black" width="20" height="10" rx="0"/>
+        <rect ry="0" x="-27" y="85" antialias="false" style="line-style:normal;line-weight:thin;filling:white;color:black" width="20" height="10" rx="0"/>
+        <rect ry="0" x="-27" y="105" antialias="false" style="line-style:normal;line-weight:thin;filling:white;color:black" width="20" height="10" rx="0"/>
+        <rect ry="0" x="-27" y="145" antialias="false" style="line-style:normal;line-weight:thin;filling:white;color:black" width="20" height="10" rx="0"/>
+        <rect ry="0" x="-27" y="165" antialias="false" style="line-style:normal;line-weight:thin;filling:white;color:black" width="20" height="10" rx="0"/>
+        <rect ry="0" x="-27" y="185" antialias="false" style="line-style:normal;line-weight:thin;filling:white;color:black" width="20" height="10" rx="0"/>
+        <rect ry="0" x="-27" y="199" antialias="false" style="line-style:normal;line-weight:thin;filling:white;color:black" width="20" height="10" rx="0"/>
+        <rect ry="0" x="-27" y="45" antialias="false" style="line-style:normal;line-weight:thin;filling:white;color:black" width="20" height="10" rx="0"/>
+        <rect ry="0" x="-27" y="125" antialias="false" style="line-style:normal;line-weight:thin;filling:white;color:black" width="20" height="10" rx="0"/>
+        <text x="20" y="76" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="1"/>
+        <text x="20" y="116" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="6"/>
+        <text x="20" y="156" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="5"/>
+        <text x="20" y="196" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="7"/>
+        <circle x="-13.96" y="97.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-22.4" y="216.6" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.8"/>
+        <circle x="12.4" y="133.7" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="12.4" y="173.7" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="12.4" y="93.7" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="12.4" y="53.7" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="10.9" y="138.9" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="10.9" y="98.9" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="10.9" y="178.9" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="10.9" y="58.9" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="9.2" y="184.1" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="9.2" y="104.1" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="9.2" y="144.1" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="9.2" y="64.1" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="5.6" y="177.6" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="5.6" y="97.6" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="5.6" y="137.6" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-13.96" y="137.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="16.1" y="180.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="16.1" y="100.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="16.1" y="140.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="3" y="91" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="18"/>
+        <circle x="3" y="131" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="18"/>
+        <circle x="-13.96" y="177.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="3" y="171" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="18"/>
+        <circle x="-0.5" y="127.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="25"/>
+        <circle x="-0.5" y="87.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="25"/>
+        <circle x="5.6" y="57.6" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-0.5" y="167.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="25"/>
+        <polygon y1="143.65" antialias="false" y2="141.79" y3="143.1" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="3.89" y4="145.11" x2="6.98" x3="7.76" x4="4.72"/>
+        <polygon y1="103.65" antialias="false" y2="101.79" y3="103.1" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="3.89" y4="105.11" x2="6.98" x3="7.76" x4="4.72"/>
+        <polygon y1="183.65" antialias="false" y2="181.79" y3="183.1" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="3.89" y4="185.11" x2="6.98" x3="7.76" x4="4.72"/>
+        <circle x="16.1" y="60.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <text x="0" y="116" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="2"/>
+        <text x="0" y="156" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="4"/>
+        <text x="0" y="196" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="6"/>
+        <text x="1" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="OUT"/>
+        <circle x="-24.5" y="97.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-24.5" y="137.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-24.5" y="177.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="7.9" y="218.9" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLYellowGold;color:black" diameter="12.2"/>
+        <circle x="-21.25" y="217.75" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGraySilver;color:black" diameter="14.5"/>
+        <circle x="-19.3" y="219.7" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGrayDimGray;color:black" diameter="10.6"/>
+        <circle x="5.6" y="216.6" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.8"/>
+        <circle x="14.9" y="221.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-12.9" y="221.7" antialias="false" style="line-style:normal;line-weight:thin;filling:HTMLYellowGold;color:black" diameter="1.8"/>
+        <circle x="-17.9" y="226.6" antialias="false" style="line-style:normal;line-weight:thin;filling:HTMLYellowGold;color:black" diameter="1.8"/>
+        <arc x="-21.61" y="245.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="54.5" width="8" height="8" angle="24.8125"/>
+        <circle x="9.9" y="226.4" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-16.9" y="221.7" antialias="false" style="line-style:normal;line-weight:thin;filling:HTMLYellowGold;color:black" diameter="1.8"/>
+        <circle x="10.9" y="221.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="17.44" y="-1.49" antialias="false" style="line-style:normal;line-weight:thin;filling:gray;color:black" diameter="11.2"/>
+        <circle x="15.9" y="226.4" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-11.9" y="226.6" antialias="false" style="line-style:normal;line-weight:thin;filling:HTMLYellowGold;color:black" diameter="1.8"/>
+        <line end1="none" end2="none" y1="247.06" antialias="false" y2="248.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-14.78" length1="3" x2="-13.13" length2="3"/>
+        <arc x="-14.3" y="241.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="8" height="8" angle="-45"/>
+        <arc x="-29" y="236" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="0" width="12" height="12" angle="90"/>
+        <line end1="none" end2="none" y1="236" antialias="false" y2="236" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-23" length1="1.5" x2="-30" length2="1.5"/>
+        <circle x="3" y="51" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="18"/>
+        <circle x="-22.4" y="11.6" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.8"/>
+        <line end1="none" end2="none" y1="243" antialias="false" y2="245.86" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="-17" length2="1.5"/>
+        <circle x="-0.5" y="47.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="25"/>
+        <arc x="13.61" y="-6.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="234.5" width="8" height="8" angle="24.8125"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="31.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-30" length1="1.5" x2="-21" length2="1.5"/>
+        <line end1="none" end2="none" y1="-0.06" antialias="false" y2="-1.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="14.78" length1="3" x2="13.13" length2="3"/>
+        <circle x="-28.56" y="237.51" antialias="false" style="line-style:normal;line-weight:thin;filling:gray;color:black" diameter="11.2"/>
+        <arc x="6.3" y="-2.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="-45"/>
+        <circle x="-26" y="240" antialias="false" style="line-style:normal;line-weight:thin;filling:white;color:black" diameter="6"/>
+        <circle x="-20.1" y="13.9" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGreenLimeGreen;color:black" diameter="12.2"/>
+        <circle x="-13.96" y="57.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-24.5" y="57.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="35.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-21" length1="1.5" x2="-17" length2="1.5"/>
+        <circle x="16.04" y="203.41" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <line end1="none" end2="none" y1="35.5" antialias="false" y2="35.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="31.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="30" length1="1.5" x2="21" length2="1.5"/>
+        <circle x="7.04" y="203.41" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="35.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="21" length1="1.5" x2="17" length2="1.5"/>
+        <circle x="-13.1" y="16.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-18.1" y="21.4" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-17.1" y="16.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="7.9" y="13.9" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGreenLimeGreen;color:black" diameter="12.2"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-8" y="114" z="99" rotation="0" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{4716c2f4-3f3a-441c-93c8-f90e91168538}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
+            <text>EP1918-0002</text>
+            <info_name>designation</info_name>
+        </dynamic_text>
+        <circle x="-12.1" y="21.4" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="195.4" z="101" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <circle x="5.6" y="11.6" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.8"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="181.4" z="103" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <circle x="14.9" y="16.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21.04" y="61.5" z="105" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21.04" y="141.5" z="106" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <circle x="9.9" y="21.4" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="121.5" z="108" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="81.5" z="109" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="161.5" z="110" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="41.5" z="111" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="101.4" z="112" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <circle x="10.9" y="16.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="15.9" y="21.4" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <line end1="none" end2="none" y1="135.51" antialias="false" y2="135.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.71" length1="3" x2="30.04" length2="3"/>
+        <arc x="-21.61" y="-6.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="8" height="8" angle="45"/>
+        <line end1="none" end2="none" y1="-0.06" antialias="false" y2="-1.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-14.78" length1="3" x2="-13.13" length2="3"/>
+        <arc x="13.7" y="246.11" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
+        <circle x="2" y="9.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-2.5" y="26.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-7" y="9.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <line end1="none" end2="none" y1="133.71" antialias="false" y2="133.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="29.71" length2="3"/>
+        <arc x="-14.3" y="-2.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="216" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-30" length1="1.5" x2="-21" length2="1.5"/>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-21" length1="1.5" x2="-17" length2="1.5"/>
+        <line end1="none" end2="none" y1="212" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="216" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="30" length1="1.5" x2="21" length2="1.5"/>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="21" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="247.63" antialias="false" y2="249.63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="14.53" length1="3" x2="12.53" length2="3"/>
+        <line end1="none" end2="none" y1="246.13" antialias="false" y2="246.11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="28.94" length1="3" x2="18.51" length2="3"/>
+        <line end1="none" end2="none" y1="1.11" antialias="false" y2="1.11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.14" length1="3" x2="-17.61" length2="3"/>
+        <circle x="20" y="1" antialias="false" style="line-style:normal;line-weight:thin;filling:white;color:black" diameter="6"/>
+        <arc x="17" y="-1" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="180" width="12" height="12" angle="90"/>
+        <line end1="none" end2="none" y1="11" antialias="false" y2="11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="23" length1="1.5" x2="30" length2="1.5"/>
+        <line end1="none" end2="none" y1="4" antialias="false" y2="1.14" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="17" length1="1.5" x2="17" length2="1.5"/>
+        <text x="-29" y="123.7" font="Liberation Sans,3,-1,5,75,0,0,0,0,0,Bold" rotation="0" color="#000000" text="BECKHOFF"/>
+        <text x="-13" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
+        <polygon y1="63.65" antialias="false" y2="61.79" y3="63.1" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="3.89" y4="65.11" x2="6.98" x3="7.76" x4="4.72"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-30" y="-30" z="139" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
+            <text></text>
+            <info_name>label</info_name>
+        </dynamic_text>
+        <text x="0" y="76" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="0"/>
+        <circle x="-5" y="236.5" antialias="false" style="line-style:normal;line-weight:thin;filling:HTMLGraySilver;color:black" diameter="10"/>
+        <circle x="-4" y="237.5" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGraySilver;color:black" diameter="8"/>
+        <line end1="none" end2="none" y1="241.5" antialias="false" y2="241.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-2" length1="1.5" x2="2" length2="1.5"/>
+        <line end1="none" end2="none" y1="239.6" antialias="false" y2="243.6" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="0" length1="1.5" x2="0" length2="1.5"/>
+        <line end1="none" end2="none" y1="236" antialias="false" y2="243" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="11" length1="1.5" x2="11" length2="1.5"/>
+        <arc x="8" y="241" antialias="true" style="line-style:normal;line-weight:thin;filling:none;color:black" start="0" width="6" height="6" angle="180"/>
+        <terminal type="Generic" x="20" y="180" name="X04" uuid="{5ed505f8-b8f7-42de-98db-d2b9f6c9c6bc}" orientation="e"/>
+        <terminal type="Generic" x="20" y="60" name="X01" uuid="{c905d889-7b5a-4d9e-8e4e-2770b5067a5f}" orientation="e"/>
+        <terminal type="Generic" x="20" y="140" name="X03" uuid="{ba421d53-0a59-489c-a38f-c31a98bdf882}" orientation="e"/>
+        <terminal type="Generic" x="-20" y="20" name="X40" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
+        <terminal type="Generic" x="20" y="225" name="X61" uuid="{abccdad0-3c05-4838-874c-77a77b3b084a}" orientation="e"/>
+        <terminal type="Generic" x="20" y="20" name="X41" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+        <terminal type="Generic" x="20" y="100" name="X02" uuid="{ee1b0a90-35db-4c4c-b4bd-5699eccdb43a}" orientation="e"/>
+        <terminal type="Generic" x="0" y="248" name="PE" uuid="{07a9fa60-40a4-4e2f-825d-86d48409e2e7}" orientation="s"/>
+        <terminal type="Generic" x="-20" y="225" name="X60" uuid="{d6b16f7c-30d4-436e-a507-9ce7f57228b2}" orientation="w"/>
+    </description>
+</definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/ep_126x30_4xm12a-5_twinsafe.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/ep_126x30_4xm12a-5_twinsafe.elmt
@@ -1,5 +1,5 @@
 <definition type="element" link_type="simple" hotspot_x="35" hotspot_y="6" width="70" height="260" version="0.100.1">
-    <uuid uuid="{573d7d7e-ba8b-41e2-b9c1-c55f4197cfc3}"/>
+    <uuid uuid="{0f3fb12c-bcaf-4f8f-8b31-166c53c89816}"/>
     <names>
         <name lang="de">EP19xx |1:1| 126,5x30mm | 4x M12-Buchse, 5-polig, A-kodiert</name>
         <name lang="en">EP19xx |1:1| 126.5x30mm | 4x M12-socket, 5-pol, a-coded</name>
@@ -108,7 +108,7 @@
         <circle x="-18.1" y="21.4" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
         <circle x="-17.1" y="16.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
         <circle x="7.9" y="13.9" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGreenLimeGreen;color:black" diameter="12.2"/>
-        <dynamic_text frame="false" Halignment="AlignLeft" x="-8" y="114" z="99" rotation="0" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{4716c2f4-3f3a-441c-93c8-f90e91168538}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-8" y="114.7" z="99" rotation="0" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{4716c2f4-3f3a-441c-93c8-f90e91168538}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
             <text>EP1918-0002</text>
             <info_name>designation</info_name>
         </dynamic_text>
@@ -166,7 +166,7 @@
         <arc x="17" y="-1" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="180" width="12" height="12" angle="90"/>
         <line end1="none" end2="none" y1="11" antialias="false" y2="11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="23" length1="1.5" x2="30" length2="1.5"/>
         <line end1="none" end2="none" y1="4" antialias="false" y2="1.14" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="17" length1="1.5" x2="17" length2="1.5"/>
-        <text x="-29" y="123.7" font="Liberation Sans,3,-1,5,75,0,0,0,0,0,Bold" rotation="0" color="#000000" text="BECKHOFF"/>
+        <text x="-28" y="123.4" font="Liberation Sans,3,-1,5,75,0,0,0,0,0,Bold" rotation="0" color="#000000" text="BECKHOFF"/>
         <text x="-13" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
         <polygon y1="63.65" antialias="false" y2="61.79" y3="63.1" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="3.89" y4="65.11" x2="6.98" x3="7.76" x4="4.72"/>
         <dynamic_text frame="false" Halignment="AlignLeft" x="-30" y="-30" z="139" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
@@ -176,18 +176,18 @@
         <text x="0" y="76" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="0"/>
         <circle x="-5" y="236.5" antialias="false" style="line-style:normal;line-weight:thin;filling:HTMLGraySilver;color:black" diameter="10"/>
         <circle x="-4" y="237.5" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGraySilver;color:black" diameter="8"/>
-        <line end1="none" end2="none" y1="241.5" antialias="false" y2="241.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-2" length1="1.5" x2="2" length2="1.5"/>
-        <line end1="none" end2="none" y1="239.6" antialias="false" y2="243.6" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="0" length1="1.5" x2="0" length2="1.5"/>
+        <line end1="none" end2="none" y1="241.5" antialias="false" y2="241.5" style="line-style:normal;line-weight:normal;filling:none;color:HTMLGrayDimGray" x1="-2" length1="1.5" x2="2" length2="1.5"/>
+        <line end1="none" end2="none" y1="239.6" antialias="false" y2="243.6" style="line-style:normal;line-weight:normal;filling:none;color:HTMLGrayDimGray" x1="0" length1="1.5" x2="0" length2="1.5"/>
         <line end1="none" end2="none" y1="236" antialias="false" y2="243" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="11" length1="1.5" x2="11" length2="1.5"/>
         <arc x="8" y="241" antialias="true" style="line-style:normal;line-weight:thin;filling:none;color:black" start="0" width="6" height="6" angle="180"/>
-        <terminal type="Generic" x="20" y="180" name="X04" uuid="{5ed505f8-b8f7-42de-98db-d2b9f6c9c6bc}" orientation="e"/>
-        <terminal type="Generic" x="20" y="60" name="X01" uuid="{c905d889-7b5a-4d9e-8e4e-2770b5067a5f}" orientation="e"/>
+        <terminal type="Generic" x="20" y="100" name="X02" uuid="{ee1b0a90-35db-4c4c-b4bd-5699eccdb43a}" orientation="e"/>
         <terminal type="Generic" x="20" y="140" name="X03" uuid="{ba421d53-0a59-489c-a38f-c31a98bdf882}" orientation="e"/>
         <terminal type="Generic" x="-20" y="20" name="X40" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
         <terminal type="Generic" x="20" y="225" name="X61" uuid="{abccdad0-3c05-4838-874c-77a77b3b084a}" orientation="e"/>
-        <terminal type="Generic" x="20" y="20" name="X41" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
-        <terminal type="Generic" x="20" y="100" name="X02" uuid="{ee1b0a90-35db-4c4c-b4bd-5699eccdb43a}" orientation="e"/>
         <terminal type="Generic" x="0" y="248" name="PE" uuid="{07a9fa60-40a4-4e2f-825d-86d48409e2e7}" orientation="s"/>
         <terminal type="Generic" x="-20" y="225" name="X60" uuid="{d6b16f7c-30d4-436e-a507-9ce7f57228b2}" orientation="w"/>
+        <terminal type="Generic" x="20" y="20" name="X41" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+        <terminal type="Generic" x="20" y="180" name="X04" uuid="{5ed505f8-b8f7-42de-98db-d2b9f6c9c6bc}" orientation="e"/>
+        <terminal type="Generic" x="20" y="60" name="X01" uuid="{c905d889-7b5a-4d9e-8e4e-2770b5067a5f}" orientation="e"/>
     </description>
 </definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/ep_126x30_4xm12a-5_twinsafe_x2.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/ep_126x30_4xm12a-5_twinsafe_x2.elmt
@@ -1,0 +1,202 @@
+<definition type="element" link_type="simple" hotspot_x="65" hotspot_y="8" width="130" height="510" version="0.100.1">
+    <uuid uuid="{9998dcc8-ae4b-4f92-918e-65fa453913fd}"/>
+    <names>
+        <name lang="de">EP19xx |2:1| 126,5x30mm | 4x M12-Buchse, 5-polig, A-kodiert</name>
+        <name lang="en">EP19xx |2:1| 126.5x30mm | 4x M12-socket, 5-pol, a-coded</name>
+    </names>
+    <elementInformations>
+        <elementInformation name="designation" show="1">EP1918-0002</elementInformation>
+        <elementInformation name="manufacturer" show="1">Beckhoff</elementInformation>
+    </elementInformations>
+    <informations>Author: Moritz Scholjegerdes</informations>
+    <description>
+        <rect ry="14" x="-60" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLYellowGold;color:black" width="120" height="506" rx="14"/>
+        <line end1="none" end2="none" y1="488.68" antialias="false" y2="488.68" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="20.85" length1="1.5" x2="18.95" length2="1.5"/>
+        <rect ry="0" x="-54" y="130" antialias="false" style="line-style:normal;line-weight:thin;filling:white;color:black" width="40" height="20" rx="0"/>
+        <line end1="none" end2="none" y1="484.6" antialias="false" y2="484.6" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="23.7" length1="1.5" x2="16.1" length2="1.5"/>
+        <rect ry="0" x="-54" y="170" antialias="false" style="line-style:normal;line-weight:thin;filling:white;color:black" width="40" height="20" rx="0"/>
+        <line end1="none" end2="none" y1="486.35" antialias="false" y2="486.35" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="22.94" length1="1.5" x2="17.24" length2="1.5"/>
+        <circle x="-9.5" y="470.5" antialias="false" style="line-style:normal;line-weight:thin;filling:HTMLGraySilver;color:black" diameter="19"/>
+        <rect ry="0" x="-54" y="210" antialias="false" style="line-style:normal;line-weight:thin;filling:white;color:black" width="40" height="20" rx="0"/>
+        <rect ry="0" x="-54" y="290" antialias="false" style="line-style:normal;line-weight:thin;filling:white;color:black" width="40" height="20" rx="0"/>
+        <circle x="-7.5" y="472.5" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGraySilver;color:black" diameter="15"/>
+        <line end1="none" end2="none" y1="480" antialias="false" y2="480" style="line-style:normal;line-weight:hight;filling:none;color:HTMLGrayDimGray" x1="-3.5" length1="1.5" x2="3.5" length2="1.5"/>
+        <rect ry="0" x="-54" y="330" antialias="false" style="line-style:normal;line-weight:thin;filling:white;color:black" width="40" height="20" rx="0"/>
+        <line end1="none" end2="none" y1="476.5" antialias="false" y2="483.5" style="line-style:normal;line-weight:hight;filling:none;color:HTMLGrayDimGray" x1="0" length1="1.5" x2="0" length2="1.5"/>
+        <rect ry="0" x="-54" y="370" antialias="false" style="line-style:normal;line-weight:thin;filling:white;color:black" width="40" height="20" rx="0"/>
+        <rect ry="0" x="-54" y="396" antialias="false" style="line-style:normal;line-weight:thin;filling:white;color:black" width="40" height="20" rx="0"/>
+        <line end1="none" end2="none" y1="471" antialias="false" y2="484.6" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="19.9" length1="1.5" x2="19.9" length2="1.5"/>
+        <arc x="14.2" y="480.72" antialias="true" style="line-style:normal;line-weight:thin;filling:none;color:black" start="0" width="11.4" height="11.65" angle="180"/>
+        <rect ry="0" x="-54" y="90" antialias="false" style="line-style:normal;line-weight:thin;filling:white;color:black" width="40" height="20" rx="0"/>
+        <rect ry="0" x="-54" y="250" antialias="false" style="line-style:normal;line-weight:thin;filling:white;color:black" width="40" height="20" rx="0"/>
+        <line end1="none" end2="none" y1="290.3" antialias="false" y2="286.31" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="9.8" length1="1.5" x2="16.87" length2="1.5"/>
+        <line end1="none" end2="none" y1="130.3" antialias="false" y2="126.31" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="9.8" length1="1.5" x2="16.87" length2="1.5"/>
+        <line end1="none" end2="none" y1="210.3" antialias="false" y2="206.31" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="9.8" length1="1.5" x2="16.87" length2="1.5"/>
+        <circle x="-28" y="355" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <line end1="none" end2="none" y1="370.3" antialias="false" y2="366.31" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="9.8" length1="1.5" x2="16.87" length2="1.5"/>
+        <text x="41" y="228" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="3"/>
+        <text x="41" y="148" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="1"/>
+        <circle x="24.9" y="187.3" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <text x="41" y="388" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="7"/>
+        <circle x="21.8" y="197.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <text x="41" y="308" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="5"/>
+        <circle x="15.8" y="27.8" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGreenLimeGreen;color:black" diameter="24.4"/>
+        <circle x="18.4" y="208.2" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="24.9" y="347.3" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-28" y="115" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="21.8" y="357.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="11.2" y="195.2" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-28" y="275" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="32.3" y="201" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-28" y="195" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="18.4" y="368.2" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="6" y="182" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="36"/>
+        <circle x="-50" y="275" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="11.2" y="355.2" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-1" y="175" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="50"/>
+        <circle x="32.3" y="361" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-50" y="355" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="6" y="342" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="36"/>
+        <circle x="-50" y="195" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <text x="1" y="228" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="2"/>
+        <circle x="-1" y="335" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="50"/>
+        <line end1="none" end2="none" y1="207" antialias="false" y2="203.01" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="7.5" length1="1.5" x2="14.57" length2="1.5"/>
+        <circle x="-43" y="435" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGraySilver;color:black" diameter="30"/>
+        <arc x="13.7" y="202.7" antialias="true" style="line-style:normal;line-weight:thin;filling:none;color:black" start="305" width="4" height="4" angle="180"/>
+        <text x="1" y="388" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="6"/>
+        <circle x="24.9" y="107.3" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <line end1="none" end2="none" y1="367" antialias="false" y2="363.01" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="7.5" length1="1.5" x2="14.57" length2="1.5"/>
+        <circle x="21.8" y="117.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="15.8" y="437.8" antialias="false" style="line-style:normal;line-weight:normal;filling:gray;color:black" diameter="24.4"/>
+        <arc x="13.7" y="362.7" antialias="true" style="line-style:normal;line-weight:thin;filling:none;color:black" start="305" width="4" height="4" angle="180"/>
+        <circle x="24.9" y="267.3" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="18.4" y="128.2" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="21.8" y="277.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="18.4" y="288.2" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="29.8" y="32.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="11.2" y="275.2" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="11.2" y="115.2" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="29.8" y="442.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="32.3" y="281" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="32.3" y="121" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="6" y="262" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="36"/>
+        <circle x="6" y="102" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="36"/>
+        <circle x="-1" y="255" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="50"/>
+        <text x="2" y="13" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="OUT"/>
+        <text x="1" y="308" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="4"/>
+        <circle x="-1" y="95" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="50"/>
+        <line end1="none" end2="none" y1="287" antialias="false" y2="283.01" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="7.5" length1="1.5" x2="14.57" length2="1.5"/>
+        <arc x="13.7" y="282.7" antialias="true" style="line-style:normal;line-weight:thin;filling:none;color:black" start="305" width="4" height="4" angle="180"/>
+        <circle x="19.8" y="452.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="19.8" y="42.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <text x="1" y="148" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="0"/>
+        <arc x="-43.22" y="492.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="51.4375" width="16" height="16" angle="28.5"/>
+        <circle x="21.8" y="442.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="21.8" y="32.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="31.8" y="42.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="34.88" y="-3" antialias="false" style="line-style:normal;line-weight:thin;filling:gray;color:black" diameter="22.4"/>
+        <circle x="31.8" y="452.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-44.8" y="433.2" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
+        <circle x="-40" y="438" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGrayDimGray;color:black" diameter="24"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-9" y="233.8" z="88" rotation="0" font="Liberation Sans,7,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{b5ec55a8-7f78-1b91-4ada-ed2333c17cda}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
+            <text>EP1918-0002</text>
+            <info_name>designation</info_name>
+        </dynamic_text>
+        <circle x="-25.75" y="443.25" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLYellowGold;color:black" diameter="3.5"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="328.5" z="89" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <circle x="-35.75" y="453.25" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLYellowGold;color:black" diameter="3.5"/>
+        <line end1="none" end2="none" y1="494.42" antialias="false" y2="497.74" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.56" length1="6" x2="-26.26" length2="6"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="248.5" z="91" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <circle x="-33.75" y="443.25" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLYellowGold;color:black" diameter="3.5"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.58" y="288.5" z="93" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <circle x="-23.75" y="453.25" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLYellowGold;color:black" diameter="3.5"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="88.5" z="94" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <circle x="11.2" y="433.2" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
+        <arc x="-28.6" y="484.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="225" width="16" height="16" angle="45"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="208.5" z="95" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <arc x="-58" y="472.3" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="0" width="24" height="24" angle="90"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.58" y="128.5" z="97" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="394.5" z="98" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="368.5" z="99" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <line end1="none" end2="none" y1="472.3" antialias="false" y2="472.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-46" length1="3" x2="-60" length2="3"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="168.5" z="100" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <circle x="-44.8" y="23.2" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
+        <line end1="none" end2="none" y1="485.04" antialias="false" y2="492.02" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="-34" length2="3"/>
+        <arc x="27.22" y="-13.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="231.25" width="16" height="16" angle="28.6875"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-60" length1="3" x2="-42" length2="3"/>
+        <line end1="none" end2="none" y1="-0.12" antialias="false" y2="-3.44" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="29.56" length1="6" x2="26.26" length2="6"/>
+        <circle x="-57.12" y="475.3" antialias="false" style="line-style:normal;line-weight:thin;filling:gray;color:black" diameter="22.4"/>
+        <arc x="12.6" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="45" width="16" height="16" angle="45"/>
+        <circle x="-52" y="480.3" antialias="false" style="line-style:normal;line-weight:thin;filling:white;color:black" diameter="12"/>
+        <circle x="-40.2" y="27.8" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGreenLimeGreen;color:black" diameter="24.4"/>
+        <circle x="-50" y="115" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="71" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-42" length1="3" x2="-34" length2="3"/>
+        <circle x="32.08" y="404.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <line end1="none" end2="none" y1="71" antialias="false" y2="71" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="60" length1="3" x2="42" length2="3"/>
+        <circle x="14.08" y="404.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="71" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="42" length1="3" x2="34" length2="3"/>
+        <circle x="-26.2" y="32.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-36.2" y="42.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-34.2" y="32.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-24.2" y="42.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="11.2" y="23.2" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
+        <line end1="none" end2="none" y1="271" antialias="false" y2="326.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="60.08" length2="6"/>
+        <line end1="none" end2="none" y1="271" antialias="false" y2="271" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="59.42" length1="6" x2="60.08" length2="6"/>
+        <arc x="-43.22" y="-13.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="16" height="16" angle="45"/>
+        <line end1="none" end2="none" y1="-0.12" antialias="false" y2="-3.44" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.56" length1="6" x2="-26.26" length2="6"/>
+        <arc x="27.4" y="492.52" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="16" height="16" angle="45"/>
+        <circle x="4" y="17.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-5" y="53.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-14" y="17.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <line end1="none" end2="none" y1="267.42" antialias="false" y2="267.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="59.42" length2="6"/>
+        <arc x="-28.6" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="16" height="16" angle="45"/>
+        <line end1="none" end2="none" y1="432.3" antialias="false" y2="432.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-60" length1="3" x2="-42" length2="3"/>
+        <line end1="none" end2="none" y1="432.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-42" length1="3" x2="-34" length2="3"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-49" y="-36" z="140" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
+            <text></text>
+            <info_name>label</info_name>
+        </dynamic_text>
+        <line end1="none" end2="none" y1="424.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="432.3" antialias="false" y2="432.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="60" length1="3" x2="42" length2="3"/>
+        <line end1="none" end2="none" y1="432.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="42" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="495.56" antialias="false" y2="499.56" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="29.06" length1="6" x2="25.06" length2="6"/>
+        <line end1="none" end2="none" y1="492.56" antialias="false" y2="492.53" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="57.88" length1="6" x2="36.02" length2="6"/>
+        <line end1="none" end2="none" y1="2.22" antialias="false" y2="2.22" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-58.28" length1="6" x2="-35.22" length2="6"/>
+        <circle x="40" y="2" antialias="false" style="line-style:normal;line-weight:thin;filling:white;color:black" diameter="12"/>
+        <arc x="34" y="-2" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="180" width="24" height="24" angle="90"/>
+        <line end1="none" end2="none" y1="22" antialias="false" y2="22" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="46" length1="3" x2="60" length2="3"/>
+        <line end1="none" end2="none" y1="9" antialias="false" y2="2.28" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="34" length1="3" x2="34" length2="3"/>
+        <text x="-55.2" y="246.7" font="Liberation Sans,6,-1,5,75,0,0,0,0,0,Bold" rotation="0" color="#000000" text="BECKHOFF"/>
+        <text x="-26" y="13" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
+        <line end1="none" end2="none" y1="127" antialias="false" y2="123.01" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="7.5" length1="1.5" x2="14.57" length2="1.5"/>
+        <arc x="13.7" y="122.7" antialias="true" style="line-style:normal;line-weight:thin;filling:none;color:black" start="305" width="4" height="4" angle="180"/>
+        <terminal type="Generic" x="40" y="360" name="X04" uuid="{6450aa25-49c8-4ece-bf59-765f071f9084}" orientation="e"/>
+        <terminal type="Generic" x="40" y="280" name="X03" uuid="{4afd153b-5c53-4afb-a2a8-77c8dbda0ee0}" orientation="e"/>
+        <terminal type="Generic" x="40" y="120" name="X01" uuid="{e4d1e445-c233-400f-969b-6a62e76f2ade}" orientation="e"/>
+        <terminal type="Generic" x="-40" y="450" name="X60" uuid="{7d2effee-f301-4f55-ad88-0eb43564e57b}" orientation="w"/>
+        <terminal type="Generic" x="40" y="450" name="X61" uuid="{c42bc02a-56a4-4d65-ad62-f6cdc62649ce}" orientation="e"/>
+        <terminal type="Generic" x="40" y="40" name="X41" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+        <terminal type="Generic" x="-40" y="40" name="X40" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
+        <terminal type="Generic" x="40" y="200" name="X02" uuid="{76aa044c-60bf-4e0f-bc91-66ecbc80bd67}" orientation="e"/>
+        <terminal type="Generic" x="0" y="490" name="PE" uuid="{7ed0ebe1-82de-4e11-90f0-c455477af040}" orientation="s"/>
+    </description>
+</definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/ep_126x30_4xm12a-5_x2.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/ep_126x30_4xm12a-5_x2.elmt
@@ -1,0 +1,193 @@
+<definition type="element" link_type="simple" hotspot_x="65" hotspot_y="8" width="130" height="510" version="0.100.1">
+    <uuid uuid="{c388c909-80ee-4d37-ab70-a3fb6cf550e0}"/>
+    <names>
+        <name lang="de">EPxxxx |2:1| 126,5x30mm | 4x M12-Buchse, 5-polig, A-kodiert</name>
+        <name lang="en">EPxxxx |2:1| 126.5x30mm | 4x M12-socket, 5-pol, a-coded</name>
+    </names>
+    <elementInformations>
+        <elementInformation name="designation" show="1">EP1008-0002</elementInformation>
+        <elementInformation name="manufacturer" show="1">Beckhoff</elementInformation>
+    </elementInformations>
+    <informations>Author: Moritz Scholjegerdes</informations>
+    <description>
+        <line end1="none" end2="none" y1="290.3" antialias="false" y2="286.31" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="9.8" length1="1.5" x2="16.87" length2="1.5"/>
+        <line end1="none" end2="none" y1="130.3" antialias="false" y2="126.31" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="9.8" length1="1.5" x2="16.87" length2="1.5"/>
+        <line end1="none" end2="none" y1="210.3" antialias="false" y2="206.31" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="9.8" length1="1.5" x2="16.87" length2="1.5"/>
+        <circle x="-28" y="355" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <line end1="none" end2="none" y1="370.3" antialias="false" y2="366.31" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="9.8" length1="1.5" x2="16.87" length2="1.5"/>
+        <text x="41" y="228" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="3"/>
+        <text x="41" y="148" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="1"/>
+        <circle x="24.9" y="187.3" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <text x="41" y="388" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="7"/>
+        <circle x="21.8" y="197.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <text x="41" y="308" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="5"/>
+        <circle x="15.8" y="27.8" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGreenLimeGreen;color:black" diameter="24.4"/>
+        <circle x="18.4" y="208.2" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="24.9" y="347.3" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-28" y="115" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="21.8" y="357.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="11.2" y="195.2" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-28" y="275" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="32.3" y="201" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-28" y="195" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="18.4" y="368.2" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="6" y="182" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="36"/>
+        <circle x="-50" y="275" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="11.2" y="355.2" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-1" y="175" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="50"/>
+        <circle x="32.3" y="361" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-50" y="355" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="6" y="342" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="36"/>
+        <circle x="-50" y="195" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <text x="1" y="228" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="2"/>
+        <circle x="-1" y="335" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="50"/>
+        <line end1="none" end2="none" y1="207" antialias="false" y2="203.01" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="7.5" length1="1.5" x2="14.57" length2="1.5"/>
+        <circle x="-43" y="435" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGraySilver;color:black" diameter="30"/>
+        <arc x="13.7" y="202.7" antialias="true" style="line-style:normal;line-weight:thin;filling:none;color:black" start="305" width="4" height="4" angle="180"/>
+        <text x="1" y="388" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="6"/>
+        <circle x="24.9" y="107.3" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <line end1="none" end2="none" y1="367" antialias="false" y2="363.01" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="7.5" length1="1.5" x2="14.57" length2="1.5"/>
+        <circle x="21.8" y="117.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="15.8" y="437.8" antialias="false" style="line-style:normal;line-weight:normal;filling:gray;color:black" diameter="24.4"/>
+        <arc x="13.7" y="362.7" antialias="true" style="line-style:normal;line-weight:thin;filling:none;color:black" start="305" width="4" height="4" angle="180"/>
+        <circle x="24.9" y="267.3" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="18.4" y="128.2" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="21.8" y="277.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <rect ry="0" x="-54" y="130" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <circle x="18.4" y="288.2" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="29.8" y="32.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="11.2" y="275.2" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="11.2" y="115.2" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="29.8" y="442.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="32.3" y="281" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="32.3" y="121" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="6" y="262" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="36"/>
+        <circle x="6" y="102" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="36"/>
+        <circle x="-1" y="255" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="50"/>
+        <text x="2" y="13" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="OUT"/>
+        <text x="1" y="308" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="4"/>
+        <circle x="-1" y="95" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="50"/>
+        <line end1="none" end2="none" y1="287" antialias="false" y2="283.01" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="7.5" length1="1.5" x2="14.57" length2="1.5"/>
+        <arc x="13.7" y="282.7" antialias="true" style="line-style:normal;line-weight:thin;filling:none;color:black" start="305" width="4" height="4" angle="180"/>
+        <circle x="19.8" y="452.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="19.8" y="42.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <text x="1" y="148" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="0"/>
+        <arc x="-43.22" y="492.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="51.4375" width="16" height="16" angle="28.5"/>
+        <circle x="21.8" y="442.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="21.8" y="32.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <rect ry="0" x="-54" y="170" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <circle x="31.8" y="42.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="34.88" y="-3" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="22.4"/>
+        <circle x="31.8" y="452.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-44.8" y="433.2" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
+        <rect ry="0" x="-54" y="210" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <rect ry="0" x="-54" y="290" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <circle x="-40" y="438" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGrayDimGray;color:black" diameter="24"/>
+        <circle x="-25.75" y="443.25" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLYellowGold;color:black" diameter="3.5"/>
+        <circle x="-35.75" y="453.25" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLYellowGold;color:black" diameter="3.5"/>
+        <line end1="none" end2="none" y1="494.42" antialias="false" y2="497.74" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.56" length1="6" x2="-26.26" length2="6"/>
+        <circle x="-33.75" y="443.25" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLYellowGold;color:black" diameter="3.5"/>
+        <circle x="-23.75" y="453.25" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLYellowGold;color:black" diameter="3.5"/>
+        <circle x="11.2" y="433.2" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
+        <arc x="-28.6" y="484.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="225" width="16" height="16" angle="45"/>
+        <rect ry="0" x="-54" y="330" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <rect ry="0" x="-54" y="370" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <arc x="-58" y="472.3" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="0" width="24" height="24" angle="90"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-34" y="474.3" z="84" rotation="0" font="Liberation Sans,8,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{b5ec55a8-7f78-1b91-4ada-ed2333c17cda}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
+            <text>EP1008-0002</text>
+            <info_name>designation</info_name>
+        </dynamic_text>
+        <rect ry="0" x="-54" y="396" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="328.5" z="86" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <line end1="none" end2="none" y1="472.3" antialias="false" y2="472.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-46" length1="3" x2="-60" length2="3"/>
+        <circle x="-44.8" y="23.2" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="248.5" z="87" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.58" y="288.5" z="88" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <line end1="none" end2="none" y1="485.04" antialias="false" y2="492.02" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="-34" length2="3"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="88.5" z="89" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="208.5" z="90" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <arc x="27.22" y="-13.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="231.25" width="16" height="16" angle="28.6875"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.58" y="128.5" z="91" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="394.5" z="92" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="368.5" z="92" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-60" length1="3" x2="-42" length2="3"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="168.5" z="93" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <line end1="none" end2="none" y1="-0.12" antialias="false" y2="-3.44" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="29.56" length1="6" x2="26.26" length2="6"/>
+        <circle x="-57.12" y="475.3" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="22.4"/>
+        <arc x="12.6" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="45" width="16" height="16" angle="45"/>
+        <circle x="-52" y="480.3" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="12"/>
+        <circle x="-40.2" y="27.8" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGreenLimeGreen;color:black" diameter="24.4"/>
+        <circle x="-50" y="115" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <rect ry="0" x="-54" y="90" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="71" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-42" length1="3" x2="-34" length2="3"/>
+        <circle x="32.08" y="404.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <line end1="none" end2="none" y1="71" antialias="false" y2="71" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="60" length1="3" x2="42" length2="3"/>
+        <circle x="14.08" y="404.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="71" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="42" length1="3" x2="34" length2="3"/>
+        <circle x="-26.2" y="32.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-36.2" y="42.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-34.2" y="32.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-24.2" y="42.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="11.2" y="23.2" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
+        <line end1="none" end2="none" y1="427.42" antialias="false" y2="225" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-59.92" length1="6" x2="-59.92" length2="6"/>
+        <line end1="none" end2="none" y1="271" antialias="false" y2="326.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="60.08" length2="6"/>
+        <line end1="none" end2="none" y1="271" antialias="false" y2="271" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="59.42" length1="6" x2="60.08" length2="6"/>
+        <arc x="-43.22" y="-13.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="16" height="16" angle="45"/>
+        <line end1="none" end2="none" y1="-0.12" antialias="false" y2="-3.44" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.56" length1="6" x2="-26.26" length2="6"/>
+        <arc x="27.4" y="492.52" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="16" height="16" angle="45"/>
+        <circle x="4" y="17.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-5" y="53.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-14" y="17.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <line end1="none" end2="none" y1="267.42" antialias="false" y2="267.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="59.42" length2="6"/>
+        <arc x="-28.6" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="16" height="16" angle="45"/>
+        <rect ry="14" x="-60" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="120" height="506" rx="14"/>
+        <line end1="none" end2="none" y1="432.3" antialias="false" y2="432.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-60" length1="3" x2="-42" length2="3"/>
+        <line end1="none" end2="none" y1="432.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-42" length1="3" x2="-34" length2="3"/>
+        <line end1="none" end2="none" y1="424.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="432.3" antialias="false" y2="432.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="60" length1="3" x2="42" length2="3"/>
+        <line end1="none" end2="none" y1="432.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="42" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="495.56" antialias="false" y2="499.56" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="29.06" length1="6" x2="25.06" length2="6"/>
+        <line end1="none" end2="none" y1="492.56" antialias="false" y2="492.53" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="57.88" length1="6" x2="36.02" length2="6"/>
+        <line end1="none" end2="none" y1="2.22" antialias="false" y2="2.22" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-58.28" length1="6" x2="-35.22" length2="6"/>
+        <circle x="40" y="2" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="12"/>
+        <rect ry="0" x="-54" y="250" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <arc x="34" y="-2" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="180" width="24" height="24" angle="90"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-49" y="-36" z="141" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
+            <text></text>
+            <info_name>label</info_name>
+        </dynamic_text>
+        <line end1="none" end2="none" y1="22" antialias="false" y2="22" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="46" length1="3" x2="60" length2="3"/>
+        <line end1="none" end2="none" y1="9" antialias="false" y2="2.28" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="34" length1="3" x2="34" length2="3"/>
+        <text x="-25" y="497.3" font="Liberation Sans,7,-1,5,75,0,0,0,0,0,Bold" rotation="0" color="#000000" text="BECKHOFF"/>
+        <text x="-26" y="13" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
+        <line end1="none" end2="none" y1="127" antialias="false" y2="123.01" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="7.5" length1="1.5" x2="14.57" length2="1.5"/>
+        <arc x="13.7" y="122.7" antialias="true" style="line-style:normal;line-weight:thin;filling:none;color:black" start="305" width="4" height="4" angle="180"/>
+        <terminal type="Generic" x="-40" y="40" name="X40" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
+        <terminal type="Generic" x="40" y="280" name="X03" uuid="{4afd153b-5c53-4afb-a2a8-77c8dbda0ee0}" orientation="e"/>
+        <terminal type="Generic" x="40" y="360" name="X04" uuid="{6450aa25-49c8-4ece-bf59-765f071f9084}" orientation="e"/>
+        <terminal type="Generic" x="40" y="450" name="X61" uuid="{c42bc02a-56a4-4d65-ad62-f6cdc62649ce}" orientation="e"/>
+        <terminal type="Generic" x="40" y="40" name="X41" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+        <terminal type="Generic" x="40" y="120" name="X01" uuid="{e4d1e445-c233-400f-969b-6a62e76f2ade}" orientation="e"/>
+        <terminal type="Generic" x="40" y="200" name="X02" uuid="{76aa044c-60bf-4e0f-bc91-66ecbc80bd67}" orientation="e"/>
+        <terminal type="Generic" x="-40" y="450" name="X60" uuid="{7d2effee-f301-4f55-ad88-0eb43564e57b}" orientation="w"/>
+    </description>
+</definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/ep_126x30_4xm12a-5_x2.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/ep_126x30_4xm12a-5_x2.elmt
@@ -1,5 +1,5 @@
 <definition type="element" link_type="simple" hotspot_x="65" hotspot_y="8" width="130" height="510" version="0.100.1">
-    <uuid uuid="{c388c909-80ee-4d37-ab70-a3fb6cf550e0}"/>
+    <uuid uuid="{ec822f8a-fcff-4deb-99d1-e235b525adcf}"/>
     <names>
         <name lang="de">EPxxxx |2:1| 126,5x30mm | 4x M12-Buchse, 5-polig, A-kodiert</name>
         <name lang="en">EPxxxx |2:1| 126.5x30mm | 4x M12-socket, 5-pol, a-coded</name>
@@ -10,6 +10,7 @@
     </elementInformations>
     <informations>Author: Moritz Scholjegerdes</informations>
     <description>
+        <rect ry="14" x="-60" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="120" height="506" rx="14"/>
         <line end1="none" end2="none" y1="290.3" antialias="false" y2="286.31" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="9.8" length1="1.5" x2="16.87" length2="1.5"/>
         <line end1="none" end2="none" y1="130.3" antialias="false" y2="126.31" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="9.8" length1="1.5" x2="16.87" length2="1.5"/>
         <line end1="none" end2="none" y1="210.3" antialias="false" y2="206.31" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="9.8" length1="1.5" x2="16.87" length2="1.5"/>
@@ -93,43 +94,43 @@
         <rect ry="0" x="-54" y="330" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
         <rect ry="0" x="-54" y="370" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
         <arc x="-58" y="472.3" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="0" width="24" height="24" angle="90"/>
-        <dynamic_text frame="false" Halignment="AlignLeft" x="-34" y="474.3" z="84" rotation="0" font="Liberation Sans,8,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{b5ec55a8-7f78-1b91-4ada-ed2333c17cda}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-34" y="474.3" z="85" rotation="0" font="Liberation Sans,8,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{b5ec55a8-7f78-1b91-4ada-ed2333c17cda}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
             <text>EP1008-0002</text>
             <info_name>designation</info_name>
         </dynamic_text>
         <rect ry="0" x="-54" y="396" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="328.5" z="86" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="328.5" z="87" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text></text>
         </dynamic_text>
         <line end1="none" end2="none" y1="472.3" antialias="false" y2="472.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-46" length1="3" x2="-60" length2="3"/>
-        <circle x="-44.8" y="23.2" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="248.5" z="87" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="248.5" z="89" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text></text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.58" y="288.5" z="88" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <circle x="-44.8" y="23.2" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.58" y="288.5" z="91" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="88.5" z="92" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="208.5" z="93" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text></text>
         </dynamic_text>
         <line end1="none" end2="none" y1="485.04" antialias="false" y2="492.02" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="-34" length2="3"/>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="88.5" z="89" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.58" y="128.5" z="95" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text></text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="208.5" z="90" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="394.5" z="96" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="368.5" z="97" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="168.5" z="98" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text></text>
         </dynamic_text>
         <arc x="27.22" y="-13.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="231.25" width="16" height="16" angle="28.6875"/>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.58" y="128.5" z="91" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text></text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="394.5" z="92" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text></text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="368.5" z="92" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text></text>
-        </dynamic_text>
         <line end1="none" end2="none" y1="63" antialias="false" y2="63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-60" length1="3" x2="-42" length2="3"/>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="168.5" z="93" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text></text>
-        </dynamic_text>
         <line end1="none" end2="none" y1="-0.12" antialias="false" y2="-3.44" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="29.56" length1="6" x2="26.26" length2="6"/>
         <circle x="-57.12" y="475.3" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="22.4"/>
         <arc x="12.6" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="45" width="16" height="16" angle="45"/>
@@ -148,7 +149,6 @@
         <circle x="-34.2" y="32.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
         <circle x="-24.2" y="42.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
         <circle x="11.2" y="23.2" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
-        <line end1="none" end2="none" y1="427.42" antialias="false" y2="225" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-59.92" length1="6" x2="-59.92" length2="6"/>
         <line end1="none" end2="none" y1="271" antialias="false" y2="326.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="60.08" length2="6"/>
         <line end1="none" end2="none" y1="271" antialias="false" y2="271" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="59.42" length1="6" x2="60.08" length2="6"/>
         <arc x="-43.22" y="-13.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="16" height="16" angle="45"/>
@@ -159,7 +159,6 @@
         <circle x="-14" y="17.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
         <line end1="none" end2="none" y1="267.42" antialias="false" y2="267.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="59.42" length2="6"/>
         <arc x="-28.6" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="16" height="16" angle="45"/>
-        <rect ry="14" x="-60" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="120" height="506" rx="14"/>
         <line end1="none" end2="none" y1="432.3" antialias="false" y2="432.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-60" length1="3" x2="-42" length2="3"/>
         <line end1="none" end2="none" y1="432.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-42" length1="3" x2="-34" length2="3"/>
         <line end1="none" end2="none" y1="424.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="34" length2="3"/>
@@ -181,9 +180,9 @@
         <text x="-26" y="13" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
         <line end1="none" end2="none" y1="127" antialias="false" y2="123.01" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="7.5" length1="1.5" x2="14.57" length2="1.5"/>
         <arc x="13.7" y="122.7" antialias="true" style="line-style:normal;line-weight:thin;filling:none;color:black" start="305" width="4" height="4" angle="180"/>
+        <terminal type="Generic" x="40" y="360" name="X04" uuid="{6450aa25-49c8-4ece-bf59-765f071f9084}" orientation="e"/>
         <terminal type="Generic" x="-40" y="40" name="X40" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
         <terminal type="Generic" x="40" y="280" name="X03" uuid="{4afd153b-5c53-4afb-a2a8-77c8dbda0ee0}" orientation="e"/>
-        <terminal type="Generic" x="40" y="360" name="X04" uuid="{6450aa25-49c8-4ece-bf59-765f071f9084}" orientation="e"/>
         <terminal type="Generic" x="40" y="450" name="X61" uuid="{c42bc02a-56a4-4d65-ad62-f6cdc62649ce}" orientation="e"/>
         <terminal type="Generic" x="40" y="40" name="X41" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
         <terminal type="Generic" x="40" y="120" name="X01" uuid="{e4d1e445-c233-400f-969b-6a62e76f2ade}" orientation="e"/>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/ep_126x30_8xm8a-3.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/ep_126x30_8xm8a-3.elmt
@@ -1,5 +1,5 @@
 <definition type="element" link_type="simple" hotspot_x="35" hotspot_y="6" width="70" height="260" version="0.100.1">
-    <uuid uuid="{3903a461-c5bd-4fad-b596-589626958941}"/>
+    <uuid uuid="{d3317c5c-3065-402b-9035-933ef0052305}"/>
     <names>
         <name lang="de">EPxxxx |1:1| 126,5x30mm | 8x M8-Buchse, 3-polig, A-kodiert</name>
         <name lang="en">EPxxxx |1:1| 126.5x30mm | 8x M8-socket, 3-pol, a-coded</name>
@@ -131,6 +131,9 @@
         <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="41.5" z="118" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X01</text>
         </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="195.4" z="119" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
         <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.5" y="181.4" z="119" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X08</text>
         </dynamic_text>
@@ -140,19 +143,19 @@
         <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.54" y="61.5" z="121" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X02</text>
         </dynamic_text>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="216" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-30" length1="1.5" x2="-21" length2="1.5"/>
         <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="121.5" z="122" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X05</text>
         </dynamic_text>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-21" length1="1.5" x2="-17" length2="1.5"/>
         <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.5" y="101.4" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X04</text>
         </dynamic_text>
+        <line end1="none" end2="none" y1="212" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="216" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="30" length1="1.5" x2="21" length2="1.5"/>
         <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="81.5" z="124" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X03</text>
         </dynamic_text>
-        <line end1="none" end2="none" y1="216" antialias="false" y2="216" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-30" length1="1.5" x2="-21" length2="1.5"/>
-        <line end1="none" end2="none" y1="216" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-21" length1="1.5" x2="-17" length2="1.5"/>
-        <line end1="none" end2="none" y1="212" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="17" length2="1.5"/>
-        <line end1="none" end2="none" y1="216" antialias="false" y2="216" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="30" length1="1.5" x2="21" length2="1.5"/>
         <line end1="none" end2="none" y1="216" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="21" length1="1.5" x2="17" length2="1.5"/>
         <line end1="none" end2="none" y1="247.63" antialias="false" y2="249.63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="14.53" length1="3" x2="12.53" length2="3"/>
         <line end1="none" end2="none" y1="246.13" antialias="false" y2="246.11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="28.94" length1="3" x2="18.51" length2="3"/>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/ep_126x30_8xm8a-3.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/ep_126x30_8xm8a-3.elmt
@@ -1,5 +1,5 @@
 <definition type="element" link_type="simple" hotspot_x="35" hotspot_y="6" width="70" height="260" version="0.100.1">
-    <uuid uuid="{6c0eb065-82fa-4773-a125-7db678826890}"/>
+    <uuid uuid="{3903a461-c5bd-4fad-b596-589626958941}"/>
     <names>
         <name lang="de">EPxxxx |1:1| 126,5x30mm | 8x M8-Buchse, 3-polig, A-kodiert</name>
         <name lang="en">EPxxxx |1:1| 126.5x30mm | 8x M8-socket, 3-pol, a-coded</name>
@@ -10,6 +10,7 @@
     </elementInformations>
     <informations>Author: Moritz Scholjegerdes</informations>
     <description>
+        <rect ry="7" x="-30" y="-3" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="60" height="253" rx="7"/>
         <circle x="-22.4" y="216.6" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.8"/>
         <text x="1" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="OUT"/>
         <circle x="7.9" y="218.9" antialias="false" style="line-style:normal;line-weight:normal;filling:gray;color:black" diameter="12.2"/>
@@ -107,10 +108,6 @@
         <circle x="15.9" y="21.4" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
         <circle x="-19.96" y="124.11" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="12"/>
         <circle x="-22.16" y="121.91" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.4"/>
-        <line end1="none" end2="none" y1="30.71" antialias="false" y2="3.11" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.96" length1="3" x2="-29.96" length2="3"/>
-        <line end1="none" end2="none" y1="133.71" antialias="false" y2="32.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.96" length1="3" x2="-29.96" length2="3"/>
-        <line end1="none" end2="none" y1="135.51" antialias="false" y2="163.11" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="30.04" length2="3"/>
-        <line end1="none" end2="none" y1="32.51" antialias="false" y2="133.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="30.04" length2="3"/>
         <line end1="none" end2="none" y1="135.51" antialias="false" y2="135.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.71" length1="3" x2="30.04" length2="3"/>
         <arc x="-21.61" y="-6.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="8" height="8" angle="45"/>
         <line end1="none" end2="none" y1="-0.06" antialias="false" y2="-1.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-14.78" length1="3" x2="-13.13" length2="3"/>
@@ -124,35 +121,34 @@
         <circle x="-7" y="9.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
         <line end1="none" end2="none" y1="133.71" antialias="false" y2="133.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="29.71" length2="3"/>
         <arc x="-14.3" y="-2.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
-        <dynamic_text frame="false" Halignment="AlignLeft" x="-17" y="233" z="119" rotation="0" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{4716c2f4-3f3a-441c-93c8-f90e91168538}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-17" y="233" z="116" rotation="0" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{4716c2f4-3f3a-441c-93c8-f90e91168538}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
             <text>EP1008-0001</text>
             <info_name>designation</info_name>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="161.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="161.5" z="117" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X07</text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="41.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="41.5" z="118" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X01</text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.5" y="181.4" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.5" y="181.4" z="119" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X08</text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.54" y="141.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.54" y="141.5" z="120" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X06</text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.54" y="61.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.54" y="61.5" z="121" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X02</text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="121.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="121.5" z="122" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X05</text>
         </dynamic_text>
         <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.5" y="101.4" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X04</text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="81.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="81.5" z="124" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X03</text>
         </dynamic_text>
-        <rect ry="7" x="-30" y="-3" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="60" height="253" rx="7"/>
         <line end1="none" end2="none" y1="216" antialias="false" y2="216" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-30" length1="1.5" x2="-21" length2="1.5"/>
         <line end1="none" end2="none" y1="216" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-21" length1="1.5" x2="-17" length2="1.5"/>
         <line end1="none" end2="none" y1="212" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="17" length2="1.5"/>
@@ -168,21 +164,21 @@
         <line end1="none" end2="none" y1="4" antialias="false" y2="1.14" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="17" length1="1.5" x2="17" length2="1.5"/>
         <text x="-13" y="247" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="BECKHOFF"/>
         <text x="-13" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
-        <dynamic_text frame="false" Halignment="AlignLeft" x="-29" y="-30" z="141" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-29" y="-30" z="140" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
             <text></text>
             <info_name>label</info_name>
         </dynamic_text>
-        <terminal type="Generic" x="20" y="190" name="X08" uuid="{89711b8f-a5ec-4df2-8c12-0fb01846d6de}" orientation="e"/>
-        <terminal type="Generic" x="20" y="225" name="X61" uuid="{abccdad0-3c05-4838-874c-77a77b3b084a}" orientation="e"/>
-        <terminal type="Generic" x="-20" y="225" name="X60" uuid="{d6b16f7c-30d4-436e-a507-9ce7f57228b2}" orientation="w"/>
-        <terminal type="Generic" x="20" y="150" name="X06" uuid="{d3a83a40-932c-4101-9507-084e40e98956}" orientation="e"/>
-        <terminal type="Generic" x="-20" y="20" name="X40" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
-        <terminal type="Generic" x="20" y="70" name="X02" uuid="{c905d889-7b5a-4d9e-8e4e-2770b5067a5f}" orientation="e"/>
-        <terminal type="Generic" x="20" y="20" name="X41" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
         <terminal type="Generic" x="-20" y="170" name="X07" uuid="{14e34e66-542c-4270-8bb9-b8aa0c555d8c}" orientation="w"/>
-        <terminal type="Generic" x="-20" y="50" name="X01" uuid="{c4e93b46-7e00-4c88-a190-310603506254}" orientation="w"/>
-        <terminal type="Generic" x="-20" y="90" name="X03" uuid="{4e4a51e4-2c5c-4eda-8a2b-8c2f8ff5eeee}" orientation="w"/>
+        <terminal type="Generic" x="20" y="190" name="X08" uuid="{89711b8f-a5ec-4df2-8c12-0fb01846d6de}" orientation="e"/>
         <terminal type="Generic" x="20" y="110" name="X04" uuid="{c39fd782-2d8f-4380-9539-87a10b0bc2f7}" orientation="e"/>
+        <terminal type="Generic" x="-20" y="225" name="X60" uuid="{d6b16f7c-30d4-436e-a507-9ce7f57228b2}" orientation="w"/>
+        <terminal type="Generic" x="20" y="20" name="X41" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+        <terminal type="Generic" x="20" y="225" name="X61" uuid="{abccdad0-3c05-4838-874c-77a77b3b084a}" orientation="e"/>
+        <terminal type="Generic" x="-20" y="50" name="X01" uuid="{c4e93b46-7e00-4c88-a190-310603506254}" orientation="w"/>
         <terminal type="Generic" x="-20" y="130" name="X05" uuid="{89b91aef-ba1d-4b05-9753-1562d87b3246}" orientation="w"/>
+        <terminal type="Generic" x="20" y="70" name="X02" uuid="{c905d889-7b5a-4d9e-8e4e-2770b5067a5f}" orientation="e"/>
+        <terminal type="Generic" x="20" y="150" name="X06" uuid="{d3a83a40-932c-4101-9507-084e40e98956}" orientation="e"/>
+        <terminal type="Generic" x="-20" y="90" name="X03" uuid="{4e4a51e4-2c5c-4eda-8a2b-8c2f8ff5eeee}" orientation="w"/>
+        <terminal type="Generic" x="-20" y="20" name="X40" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
     </description>
 </definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/ep_126x30_8xm8a-3.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/ep_126x30_8xm8a-3.elmt
@@ -1,0 +1,188 @@
+<definition type="element" link_type="simple" hotspot_x="35" hotspot_y="6" width="70" height="260" version="0.100.1">
+    <uuid uuid="{6c0eb065-82fa-4773-a125-7db678826890}"/>
+    <names>
+        <name lang="de">EPxxxx |1:1| 126,5x30mm | 8x M8-Buchse, 3-polig, A-kodiert</name>
+        <name lang="en">EPxxxx |1:1| 126.5x30mm | 8x M8-socket, 3-pol, a-coded</name>
+    </names>
+    <elementInformations>
+        <elementInformation name="designation" show="1">EP1008-0001</elementInformation>
+        <elementInformation name="manufacturer" show="1">Beckhoff</elementInformation>
+    </elementInformations>
+    <informations>Author: Moritz Scholjegerdes</informations>
+    <description>
+        <circle x="-22.4" y="216.6" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.8"/>
+        <text x="1" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="OUT"/>
+        <circle x="7.9" y="218.9" antialias="false" style="line-style:normal;line-weight:normal;filling:gray;color:black" diameter="12.2"/>
+        <circle x="-21.25" y="217.75" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGraySilver;color:black" diameter="14.5"/>
+        <circle x="-19.3" y="219.7" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGrayDimGray;color:black" diameter="10.6"/>
+        <circle x="5.6" y="216.6" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.8"/>
+        <rect ry="0" x="-27" y="65" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <circle x="14.9" y="221.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-12.9" y="221.7" antialias="false" style="line-style:normal;line-weight:thin;filling:HTMLYellowGold;color:black" diameter="1.8"/>
+        <rect ry="0" x="7" y="85" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <circle x="-17.9" y="226.6" antialias="false" style="line-style:normal;line-weight:thin;filling:HTMLYellowGold;color:black" diameter="1.8"/>
+        <arc x="-21.61" y="245.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="54.5" width="8" height="8" angle="24.8125"/>
+        <circle x="9.9" y="226.4" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-16.9" y="221.7" antialias="false" style="line-style:normal;line-weight:thin;filling:HTMLYellowGold;color:black" diameter="1.8"/>
+        <circle x="10.9" y="221.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="17.44" y="-1.49" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="11.2"/>
+        <rect ry="0" x="-27" y="105" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <circle x="15.9" y="226.4" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-11.9" y="226.6" antialias="false" style="line-style:normal;line-weight:thin;filling:HTMLYellowGold;color:black" diameter="1.8"/>
+        <circle x="15.19" y="66.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <rect ry="0" x="-27" y="145" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <line end1="none" end2="none" y1="247.06" antialias="false" y2="248.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-14.78" length1="3" x2="-13.13" length2="3"/>
+        <circle x="15.19" y="106.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <arc x="-14.3" y="241.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="8" height="8" angle="-45"/>
+        <circle x="10.23" y="106.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <rect ry="0" x="7" y="165" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <circle x="10.23" y="66.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <rect ry="0" x="-27" y="185" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <circle x="-12.88" y="91.19" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="10.23" y="71.04" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <arc x="-29" y="236" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="0" width="12" height="12" angle="90"/>
+        <rect ry="0" x="-27" y="199" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <circle x="10.23" y="111.04" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <line end1="none" end2="none" y1="236" antialias="false" y2="236" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-23" length1="1.5" x2="-30" length2="1.5"/>
+        <circle x="8.11" y="63.96" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="12"/>
+        <circle x="8.11" y="103.96" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="12"/>
+        <circle x="-22.4" y="11.6" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.8"/>
+        <circle x="5.91" y="101.76" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.4"/>
+        <line end1="none" end2="none" y1="243" antialias="false" y2="245.86" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="-17" length2="1.5"/>
+        <circle x="5.91" y="61.76" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.4"/>
+        <arc x="13.61" y="-6.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="234.5" width="8" height="8" angle="24.8125"/>
+        <circle x="-12.88" y="86.23" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="31.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-30" length1="1.5" x2="-21" length2="1.5"/>
+        <circle x="-17.84" y="86.23" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <line end1="none" end2="none" y1="-0.06" antialias="false" y2="-1.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="14.78" length1="3" x2="13.13" length2="3"/>
+        <circle x="-28.56" y="237.51" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="11.2"/>
+        <circle x="-12.88" y="51.19" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <arc x="6.3" y="-2.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="-45"/>
+        <circle x="-19.96" y="84.11" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="12"/>
+        <circle x="-26" y="240" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="6"/>
+        <circle x="-12.88" y="46.23" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="-17.84" y="46.23" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="15.19" y="146.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="-20.1" y="13.9" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGreenLimeGreen;color:black" diameter="12.2"/>
+        <circle x="-22.16" y="81.91" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.4"/>
+        <circle x="15.19" y="186.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="-19.96" y="44.11" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="12"/>
+        <circle x="-22.16" y="41.91" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.4"/>
+        <circle x="10.23" y="186.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="-0.96" y="87.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="10.23" y="146.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="-3.96" y="107.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-12.88" y="171.19" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="10.23" y="151.04" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="-3.96" y="67.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-1" y="47.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="35.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-21" length1="1.5" x2="-17" length2="1.5"/>
+        <rect ry="0" x="7" y="45" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <circle x="10.23" y="191.04" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="8.11" y="143.96" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="12"/>
+        <circle x="16.04" y="203.41" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="8.11" y="183.96" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="12"/>
+        <circle x="5.91" y="181.76" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.4"/>
+        <circle x="5.91" y="141.76" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.4"/>
+        <line end1="none" end2="none" y1="35.5" antialias="false" y2="35.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="31.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="30" length1="1.5" x2="21" length2="1.5"/>
+        <circle x="7.04" y="203.41" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-12.88" y="166.23" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="35.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="21" length1="1.5" x2="17" length2="1.5"/>
+        <circle x="-17.84" y="166.23" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="-12.88" y="131.19" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="-19.96" y="164.11" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="12"/>
+        <circle x="-12.88" y="126.23" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="-17.84" y="126.23" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="-22.16" y="161.91" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.4"/>
+        <circle x="-13.1" y="16.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-18.1" y="21.4" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-17.1" y="16.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="7.9" y="13.9" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGreenLimeGreen;color:black" diameter="12.2"/>
+        <circle x="-12.1" y="21.4" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="5.6" y="11.6" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.8"/>
+        <circle x="14.9" y="16.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="9.9" y="21.4" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="10.9" y="16.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="15.9" y="21.4" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-19.96" y="124.11" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="12"/>
+        <circle x="-22.16" y="121.91" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.4"/>
+        <line end1="none" end2="none" y1="30.71" antialias="false" y2="3.11" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.96" length1="3" x2="-29.96" length2="3"/>
+        <line end1="none" end2="none" y1="133.71" antialias="false" y2="32.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.96" length1="3" x2="-29.96" length2="3"/>
+        <line end1="none" end2="none" y1="135.51" antialias="false" y2="163.11" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="30.04" length2="3"/>
+        <line end1="none" end2="none" y1="32.51" antialias="false" y2="133.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="30.04" length2="3"/>
+        <line end1="none" end2="none" y1="135.51" antialias="false" y2="135.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.71" length1="3" x2="30.04" length2="3"/>
+        <arc x="-21.61" y="-6.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="8" height="8" angle="45"/>
+        <line end1="none" end2="none" y1="-0.06" antialias="false" y2="-1.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-14.78" length1="3" x2="-13.13" length2="3"/>
+        <arc x="13.7" y="246.11" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
+        <circle x="-0.96" y="167.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-3.96" y="187.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-3.96" y="147.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-1" y="127.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="2" y="9.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-2.5" y="26.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-7" y="9.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <line end1="none" end2="none" y1="133.71" antialias="false" y2="133.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="29.71" length2="3"/>
+        <arc x="-14.3" y="-2.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-17" y="233" z="119" rotation="0" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{4716c2f4-3f3a-441c-93c8-f90e91168538}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
+            <text>EP1008-0001</text>
+            <info_name>designation</info_name>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="161.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X07</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="41.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X01</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.5" y="181.4" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X08</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.54" y="141.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X06</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.54" y="61.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X02</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="121.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X05</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.5" y="101.4" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X04</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="81.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X03</text>
+        </dynamic_text>
+        <rect ry="7" x="-30" y="-3" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="60" height="253" rx="7"/>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="216" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-30" length1="1.5" x2="-21" length2="1.5"/>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-21" length1="1.5" x2="-17" length2="1.5"/>
+        <line end1="none" end2="none" y1="212" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="216" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="30" length1="1.5" x2="21" length2="1.5"/>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="21" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="247.63" antialias="false" y2="249.63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="14.53" length1="3" x2="12.53" length2="3"/>
+        <line end1="none" end2="none" y1="246.13" antialias="false" y2="246.11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="28.94" length1="3" x2="18.51" length2="3"/>
+        <line end1="none" end2="none" y1="1.11" antialias="false" y2="1.11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.14" length1="3" x2="-17.61" length2="3"/>
+        <circle x="20" y="1" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="6"/>
+        <rect ry="0" x="7" y="125" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <arc x="17" y="-1" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="180" width="12" height="12" angle="90"/>
+        <line end1="none" end2="none" y1="11" antialias="false" y2="11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="23" length1="1.5" x2="30" length2="1.5"/>
+        <line end1="none" end2="none" y1="4" antialias="false" y2="1.14" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="17" length1="1.5" x2="17" length2="1.5"/>
+        <text x="-13" y="247" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="BECKHOFF"/>
+        <text x="-13" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-29" y="-30" z="141" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
+            <text></text>
+            <info_name>label</info_name>
+        </dynamic_text>
+        <terminal type="Generic" x="20" y="190" name="X08" uuid="{89711b8f-a5ec-4df2-8c12-0fb01846d6de}" orientation="e"/>
+        <terminal type="Generic" x="20" y="225" name="X61" uuid="{abccdad0-3c05-4838-874c-77a77b3b084a}" orientation="e"/>
+        <terminal type="Generic" x="-20" y="225" name="X60" uuid="{d6b16f7c-30d4-436e-a507-9ce7f57228b2}" orientation="w"/>
+        <terminal type="Generic" x="20" y="150" name="X06" uuid="{d3a83a40-932c-4101-9507-084e40e98956}" orientation="e"/>
+        <terminal type="Generic" x="-20" y="20" name="X40" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
+        <terminal type="Generic" x="20" y="70" name="X02" uuid="{c905d889-7b5a-4d9e-8e4e-2770b5067a5f}" orientation="e"/>
+        <terminal type="Generic" x="20" y="20" name="X41" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+        <terminal type="Generic" x="-20" y="170" name="X07" uuid="{14e34e66-542c-4270-8bb9-b8aa0c555d8c}" orientation="w"/>
+        <terminal type="Generic" x="-20" y="50" name="X01" uuid="{c4e93b46-7e00-4c88-a190-310603506254}" orientation="w"/>
+        <terminal type="Generic" x="-20" y="90" name="X03" uuid="{4e4a51e4-2c5c-4eda-8a2b-8c2f8ff5eeee}" orientation="w"/>
+        <terminal type="Generic" x="20" y="110" name="X04" uuid="{c39fd782-2d8f-4380-9539-87a10b0bc2f7}" orientation="e"/>
+        <terminal type="Generic" x="-20" y="130" name="X05" uuid="{89b91aef-ba1d-4b05-9753-1562d87b3246}" orientation="w"/>
+    </description>
+</definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/ep_126x30_8xm8a-3_x2.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/ep_126x30_8xm8a-3_x2.elmt
@@ -1,0 +1,186 @@
+<definition type="element" link_type="simple" hotspot_x="65" hotspot_y="8" width="130" height="510" version="0.100.1">
+    <uuid uuid="{fce89f83-5c50-4776-91c1-bf97722f2ad1}"/>
+    <names>
+        <name lang="de">EPxxxx |2:1| 126,5x30mm | 8x M8-Buchse, 3-polig, A-kodiert</name>
+        <name lang="en">EPxxxx |2:1| 126.5x30mm | 8x M8-socket, 3-pol, a-coded</name>
+    </names>
+    <elementInformations>
+        <elementInformation name="designation" show="1">EP1008-0001</elementInformation>
+        <elementInformation name="manufacturer" show="1">Beckhoff</elementInformation>
+    </elementInformations>
+    <informations>Author: Moritz Scholjegerdes</informations>
+    <description>
+        <circle x="15.8" y="27.8" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGreenLimeGreen;color:black" diameter="24.4"/>
+        <circle x="-43" y="435" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGraySilver;color:black" diameter="30"/>
+        <circle x="15.8" y="437.8" antialias="false" style="line-style:normal;line-weight:normal;filling:gray;color:black" diameter="24.4"/>
+        <rect ry="0" x="-54" y="130" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <circle x="29.8" y="32.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="29.8" y="442.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <text x="2" y="13" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="OUT"/>
+        <circle x="19.8" y="452.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="19.8" y="42.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <arc x="-43.22" y="492.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="51.4375" width="16" height="16" angle="28.5"/>
+        <circle x="21.8" y="442.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="21.8" y="32.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <rect ry="0" x="14" y="170" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <circle x="31.8" y="42.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="34.88" y="-3" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="22.4"/>
+        <circle x="31.8" y="452.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-44.8" y="433.2" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
+        <rect ry="0" x="-54" y="210" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <rect ry="0" x="-54" y="290" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <circle x="-40" y="438" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGrayDimGray;color:black" diameter="24"/>
+        <circle x="-25.75" y="443.25" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLYellowGold;color:black" diameter="3.5"/>
+        <circle x="30.38" y="132.16" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="-35.75" y="453.25" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLYellowGold;color:black" diameter="3.5"/>
+        <line end1="none" end2="none" y1="494.42" antialias="false" y2="497.74" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.56" length1="6" x2="-26.26" length2="6"/>
+        <circle x="-33.75" y="443.25" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLYellowGold;color:black" diameter="3.5"/>
+        <circle x="30.38" y="212.16" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="-23.75" y="453.25" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLYellowGold;color:black" diameter="3.5"/>
+        <circle x="20.46" y="212.16" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="11.2" y="433.2" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
+        <arc x="-28.6" y="484.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="225" width="16" height="16" angle="45"/>
+        <circle x="20.46" y="132.16" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <rect ry="0" x="14" y="330" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <circle x="-25.76" y="182.38" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <rect ry="0" x="-54" y="370" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <circle x="20.46" y="142.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <arc x="-58" y="472.3" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="0" width="24" height="24" angle="90"/>
+        <rect ry="0" x="-54" y="396" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <circle x="20.46" y="222.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <line end1="none" end2="none" y1="472.3" antialias="false" y2="472.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-46" length1="3" x2="-60" length2="3"/>
+        <circle x="16.22" y="127.92" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="24"/>
+        <circle x="-44.8" y="23.2" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
+        <circle x="16.22" y="207.92" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="24"/>
+        <line end1="none" end2="none" y1="485.04" antialias="false" y2="492.02" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="-34" length2="3"/>
+        <circle x="11.82" y="203.52" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="32.8"/>
+        <arc x="27.22" y="-13.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="231.25" width="16" height="16" angle="28.6875"/>
+        <circle x="11.82" y="123.52" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="32.8"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-60" length1="3" x2="-42" length2="3"/>
+        <circle x="-25.76" y="172.46" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <line end1="none" end2="none" y1="-0.12" antialias="false" y2="-3.44" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="29.56" length1="6" x2="26.26" length2="6"/>
+        <circle x="-35.68" y="172.46" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="-25.76" y="102.38" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="-57.12" y="475.3" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="22.4"/>
+        <circle x="-39.92" y="168.22" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="24"/>
+        <arc x="12.6" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="45" width="16" height="16" angle="45"/>
+        <circle x="-52" y="480.3" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="12"/>
+        <circle x="-25.76" y="92.46" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="-35.68" y="92.46" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="30.38" y="292.16" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="-44.32" y="163.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="32.8"/>
+        <circle x="-40.2" y="27.8" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGreenLimeGreen;color:black" diameter="24.4"/>
+        <circle x="-39.92" y="88.22" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="24"/>
+        <circle x="30.38" y="372.16" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="20.46" y="372.16" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="-44.32" y="83.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="32.8"/>
+        <circle x="-1.92" y="175.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="20.46" y="292.16" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="-7.92" y="215.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-25.76" y="342.38" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="20.46" y="302.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="-7.92" y="135.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-2" y="95" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <rect ry="0" x="14" y="90" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="71" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-42" length1="3" x2="-34" length2="3"/>
+        <circle x="20.46" y="382.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="16.22" y="287.92" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="24"/>
+        <circle x="32.08" y="404.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="16.22" y="367.92" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="24"/>
+        <circle x="11.82" y="363.52" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="32.8"/>
+        <circle x="11.82" y="283.52" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="32.8"/>
+        <line end1="none" end2="none" y1="71" antialias="false" y2="71" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="60" length1="3" x2="42" length2="3"/>
+        <circle x="14.08" y="404.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-25.76" y="332.46" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="71" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="42" length1="3" x2="34" length2="3"/>
+        <circle x="-35.68" y="332.46" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="-25.76" y="262.38" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="-39.92" y="328.22" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="24"/>
+        <circle x="-25.76" y="252.46" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="-35.68" y="252.46" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="-44.32" y="323.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="32.8"/>
+        <circle x="-26.2" y="32.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-36.2" y="42.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-34.2" y="32.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-24.2" y="42.8" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="11.2" y="23.2" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
+        <circle x="-39.92" y="248.22" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="24"/>
+        <circle x="-44.32" y="243.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="32.8"/>
+        <line end1="none" end2="none" y1="427.42" antialias="false" y2="225" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-59.92" length1="6" x2="-59.92" length2="6"/>
+        <line end1="none" end2="none" y1="271" antialias="false" y2="326.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="60.08" length2="6"/>
+        <line end1="none" end2="none" y1="271" antialias="false" y2="271" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="59.42" length1="6" x2="60.08" length2="6"/>
+        <arc x="-43.22" y="-13.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="16" height="16" angle="45"/>
+        <line end1="none" end2="none" y1="-0.12" antialias="false" y2="-3.44" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.56" length1="6" x2="-26.26" length2="6"/>
+        <arc x="27.4" y="492.52" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="16" height="16" angle="45"/>
+        <circle x="-1.92" y="335.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-7.92" y="375.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-7.92" y="295.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-2" y="255" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="4" y="17.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-5" y="53.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-14" y="17.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <line end1="none" end2="none" y1="267.42" antialias="false" y2="267.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="59.42" length2="6"/>
+        <arc x="-28.6" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="16" height="16" angle="45"/>
+        <rect ry="14" x="-60" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="120" height="506" rx="14"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-34" y="474.3" z="119" rotation="0" font="Liberation Sans,8,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{b5ec55a8-7f78-1b91-4ada-ed2333c17cda}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
+            <text>EP1008-0001</text>
+            <info_name>designation</info_name>
+        </dynamic_text>
+        <line end1="none" end2="none" y1="432.3" antialias="false" y2="432.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-60" length1="3" x2="-42" length2="3"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="328.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X07</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50" y="208.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X04</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50" y="368.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X08</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="88.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X01</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50.08" y="128.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X02</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50.08" y="288.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X06</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="168.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X03</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="248.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X05</text>
+        </dynamic_text>
+        <line end1="none" end2="none" y1="432.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-42" length1="3" x2="-34" length2="3"/>
+        <line end1="none" end2="none" y1="424.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="432.3" antialias="false" y2="432.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="60" length1="3" x2="42" length2="3"/>
+        <line end1="none" end2="none" y1="432.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="42" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="495.56" antialias="false" y2="499.56" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="29.06" length1="6" x2="25.06" length2="6"/>
+        <line end1="none" end2="none" y1="492.56" antialias="false" y2="492.53" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="57.88" length1="6" x2="36.02" length2="6"/>
+        <line end1="none" end2="none" y1="2.22" antialias="false" y2="2.22" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-58.28" length1="6" x2="-35.22" length2="6"/>
+        <circle x="40" y="2" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="12"/>
+        <rect ry="0" x="14" y="250" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <arc x="34" y="-2" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="180" width="24" height="24" angle="90"/>
+        <line end1="none" end2="none" y1="22" antialias="false" y2="22" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="46" length1="3" x2="60" length2="3"/>
+        <line end1="none" end2="none" y1="9" antialias="false" y2="2.28" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="34" length1="3" x2="34" length2="3"/>
+        <text x="-25" y="497.3" font="Liberation Sans,7,-1,5,75,0,0,0,0,0,Bold" rotation="0" color="#000000" text="BECKHOFF"/>
+        <text x="-26" y="13" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-49" y="-37" z="141" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
+            <text></text>
+            <info_name>label</info_name>
+        </dynamic_text>
+        <terminal type="Generic" x="-40" y="450" name="X60" uuid="{7d2effee-f301-4f55-ad88-0eb43564e57b}" orientation="w"/>
+        <terminal type="Generic" x="40" y="220" name="X04" uuid="{7535446c-1331-4018-9c15-84c73b3afad1}" orientation="e"/>
+        <terminal type="Generic" x="-40" y="180" name="X03" uuid="{00d62ffe-60ad-46b0-80a0-d91b1976bd03}" orientation="w"/>
+        <terminal type="Generic" x="-40" y="100" name="X01" uuid="{1aed7cea-a56f-4024-8b7e-8f99767df3c2}" orientation="w"/>
+        <terminal type="Generic" x="-40" y="40" name="X40" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
+        <terminal type="Generic" x="40" y="380" name="X08" uuid="{89711b8f-a5ec-4df2-8c12-0fb01846d6de}" orientation="e"/>
+        <terminal type="Generic" x="-40" y="260" name="X05" uuid="{89b91aef-ba1d-4b05-9753-1562d87b3246}" orientation="w"/>
+        <terminal type="Generic" x="40" y="140" name="X02" uuid="{93364ac4-dce2-4a27-b122-d99d0c237eff}" orientation="e"/>
+        <terminal type="Generic" x="40" y="300" name="X06" uuid="{d3a83a40-932c-4101-9507-084e40e98956}" orientation="e"/>
+        <terminal type="Generic" x="40" y="450" name="X61" uuid="{c42bc02a-56a4-4d65-ad62-f6cdc62649ce}" orientation="e"/>
+        <terminal type="Generic" x="-40" y="340" name="X07" uuid="{14e34e66-542c-4270-8bb9-b8aa0c555d8c}" orientation="w"/>
+        <terminal type="Generic" x="40" y="40" name="X41" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+    </description>
+</definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/ep_126x30_8xm8a-3_x2.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/ep_126x30_8xm8a-3_x2.elmt
@@ -1,5 +1,5 @@
 <definition type="element" link_type="simple" hotspot_x="65" hotspot_y="8" width="130" height="510" version="0.100.1">
-    <uuid uuid="{4d7e479f-0262-472c-9620-5f38ba864b1b}"/>
+    <uuid uuid="{dff9f8c5-bac2-40d6-b55d-721b0ffcaad6}"/>
     <names>
         <name lang="de">EPxxxx |2:1| 126,5x30mm | 8x M8-Buchse, 3-polig, A-kodiert</name>
         <name lang="en">EPxxxx |2:1| 126.5x30mm | 8x M8-socket, 3-pol, a-coded</name>
@@ -139,6 +139,9 @@
         <dynamic_text frame="false" Halignment="AlignHCenter" x="-50.08" y="128.5" z="119" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X02</text>
         </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="394.5" z="120" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
         <dynamic_text frame="false" Halignment="AlignHCenter" x="-50" y="368.5" z="120" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X08</text>
         </dynamic_text>
@@ -148,10 +151,10 @@
         <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="328.5" z="122" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X07</text>
         </dynamic_text>
+        <line end1="none" end2="none" y1="432.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-42" length1="3" x2="-34" length2="3"/>
         <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="88.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X01</text>
         </dynamic_text>
-        <line end1="none" end2="none" y1="432.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-42" length1="3" x2="-34" length2="3"/>
         <line end1="none" end2="none" y1="424.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="34" length2="3"/>
         <line end1="none" end2="none" y1="432.3" antialias="false" y2="432.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="60" length1="3" x2="42" length2="3"/>
         <line end1="none" end2="none" y1="432.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="42" length1="3" x2="34" length2="3"/>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/ep_126x30_8xm8a-3_x2.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/ep_126x30_8xm8a-3_x2.elmt
@@ -1,5 +1,5 @@
 <definition type="element" link_type="simple" hotspot_x="65" hotspot_y="8" width="130" height="510" version="0.100.1">
-    <uuid uuid="{fce89f83-5c50-4776-91c1-bf97722f2ad1}"/>
+    <uuid uuid="{4d7e479f-0262-472c-9620-5f38ba864b1b}"/>
     <names>
         <name lang="de">EPxxxx |2:1| 126,5x30mm | 8x M8-Buchse, 3-polig, A-kodiert</name>
         <name lang="en">EPxxxx |2:1| 126.5x30mm | 8x M8-socket, 3-pol, a-coded</name>
@@ -10,6 +10,7 @@
     </elementInformations>
     <informations>Author: Moritz Scholjegerdes</informations>
     <description>
+        <rect ry="14" x="-60" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="120" height="506" rx="14"/>
         <circle x="15.8" y="27.8" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGreenLimeGreen;color:black" diameter="24.4"/>
         <circle x="-43" y="435" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGraySilver;color:black" diameter="30"/>
         <circle x="15.8" y="437.8" antialias="false" style="line-style:normal;line-weight:normal;filling:gray;color:black" diameter="24.4"/>
@@ -107,7 +108,6 @@
         <circle x="11.2" y="23.2" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
         <circle x="-39.92" y="248.22" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="24"/>
         <circle x="-44.32" y="243.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="32.8"/>
-        <line end1="none" end2="none" y1="427.42" antialias="false" y2="225" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-59.92" length1="6" x2="-59.92" length2="6"/>
         <line end1="none" end2="none" y1="271" antialias="false" y2="326.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="60.08" length2="6"/>
         <line end1="none" end2="none" y1="271" antialias="false" y2="271" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="59.42" length1="6" x2="60.08" length2="6"/>
         <arc x="-43.22" y="-13.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="16" height="16" angle="45"/>
@@ -122,35 +122,34 @@
         <circle x="-14" y="17.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
         <line end1="none" end2="none" y1="267.42" antialias="false" y2="267.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="59.42" length2="6"/>
         <arc x="-28.6" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="16" height="16" angle="45"/>
-        <rect ry="14" x="-60" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="120" height="506" rx="14"/>
-        <dynamic_text frame="false" Halignment="AlignLeft" x="-34" y="474.3" z="119" rotation="0" font="Liberation Sans,8,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{b5ec55a8-7f78-1b91-4ada-ed2333c17cda}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
+        <line end1="none" end2="none" y1="432.3" antialias="false" y2="432.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-60" length1="3" x2="-42" length2="3"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-34" y="474.3" z="115" rotation="0" font="Liberation Sans,8,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{b5ec55a8-7f78-1b91-4ada-ed2333c17cda}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
             <text>EP1008-0001</text>
             <info_name>designation</info_name>
         </dynamic_text>
-        <line end1="none" end2="none" y1="432.3" antialias="false" y2="432.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-60" length1="3" x2="-42" length2="3"/>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="328.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text>X07</text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="168.5" z="116" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X03</text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50" y="208.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="248.5" z="117" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X05</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50.08" y="288.5" z="118" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X06</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50.08" y="128.5" z="119" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X02</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50" y="368.5" z="120" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X08</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50" y="208.5" z="121" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X04</text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50" y="368.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text>X08</text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="328.5" z="122" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X07</text>
         </dynamic_text>
         <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="88.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X01</text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50.08" y="128.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text>X02</text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50.08" y="288.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text>X06</text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="168.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text>X03</text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="248.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text>X05</text>
         </dynamic_text>
         <line end1="none" end2="none" y1="432.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-42" length1="3" x2="-34" length2="3"/>
         <line end1="none" end2="none" y1="424.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="34" length2="3"/>
@@ -166,21 +165,21 @@
         <line end1="none" end2="none" y1="9" antialias="false" y2="2.28" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="34" length1="3" x2="34" length2="3"/>
         <text x="-25" y="497.3" font="Liberation Sans,7,-1,5,75,0,0,0,0,0,Bold" rotation="0" color="#000000" text="BECKHOFF"/>
         <text x="-26" y="13" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
-        <dynamic_text frame="false" Halignment="AlignLeft" x="-49" y="-37" z="141" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-49" y="-37" z="138" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
             <text></text>
             <info_name>label</info_name>
         </dynamic_text>
-        <terminal type="Generic" x="-40" y="450" name="X60" uuid="{7d2effee-f301-4f55-ad88-0eb43564e57b}" orientation="w"/>
-        <terminal type="Generic" x="40" y="220" name="X04" uuid="{7535446c-1331-4018-9c15-84c73b3afad1}" orientation="e"/>
-        <terminal type="Generic" x="-40" y="180" name="X03" uuid="{00d62ffe-60ad-46b0-80a0-d91b1976bd03}" orientation="w"/>
-        <terminal type="Generic" x="-40" y="100" name="X01" uuid="{1aed7cea-a56f-4024-8b7e-8f99767df3c2}" orientation="w"/>
         <terminal type="Generic" x="-40" y="40" name="X40" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
+        <terminal type="Generic" x="-40" y="180" name="X03" uuid="{00d62ffe-60ad-46b0-80a0-d91b1976bd03}" orientation="w"/>
         <terminal type="Generic" x="40" y="380" name="X08" uuid="{89711b8f-a5ec-4df2-8c12-0fb01846d6de}" orientation="e"/>
-        <terminal type="Generic" x="-40" y="260" name="X05" uuid="{89b91aef-ba1d-4b05-9753-1562d87b3246}" orientation="w"/>
         <terminal type="Generic" x="40" y="140" name="X02" uuid="{93364ac4-dce2-4a27-b122-d99d0c237eff}" orientation="e"/>
-        <terminal type="Generic" x="40" y="300" name="X06" uuid="{d3a83a40-932c-4101-9507-084e40e98956}" orientation="e"/>
         <terminal type="Generic" x="40" y="450" name="X61" uuid="{c42bc02a-56a4-4d65-ad62-f6cdc62649ce}" orientation="e"/>
-        <terminal type="Generic" x="-40" y="340" name="X07" uuid="{14e34e66-542c-4270-8bb9-b8aa0c555d8c}" orientation="w"/>
         <terminal type="Generic" x="40" y="40" name="X41" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+        <terminal type="Generic" x="-40" y="100" name="X01" uuid="{1aed7cea-a56f-4024-8b7e-8f99767df3c2}" orientation="w"/>
+        <terminal type="Generic" x="-40" y="260" name="X05" uuid="{89b91aef-ba1d-4b05-9753-1562d87b3246}" orientation="w"/>
+        <terminal type="Generic" x="40" y="220" name="X04" uuid="{7535446c-1331-4018-9c15-84c73b3afad1}" orientation="e"/>
+        <terminal type="Generic" x="-40" y="450" name="X60" uuid="{7d2effee-f301-4f55-ad88-0eb43564e57b}" orientation="w"/>
+        <terminal type="Generic" x="40" y="300" name="X06" uuid="{d3a83a40-932c-4101-9507-084e40e98956}" orientation="e"/>
+        <terminal type="Generic" x="-40" y="340" name="X07" uuid="{14e34e66-542c-4270-8bb9-b8aa0c555d8c}" orientation="w"/>
     </description>
 </definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp9001-0060.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp9001-0060.elmt
@@ -1,5 +1,5 @@
 <definition type="element" link_type="simple" hotspot_x="35" hotspot_y="7" width="70" height="180" version="0.100.1">
-    <uuid uuid="{4ba262e6-96d6-4476-92a8-27d55d70af38}"/>
+    <uuid uuid="{431bfa7f-7509-4562-a4ea-2d28978c6f07}"/>
     <names>
         <name lang="de">EPP9001-0060 |1:1| EtherCAT P-/EtherCAT-Connector</name>
         <name lang="en">EPP9001-0060 |1:1| EtherCAT P/EtherCAT connector</name>
@@ -7,7 +7,8 @@
     <elementInformations/>
     <informations>Author: Moritz Scholjegerdes</informations>
     <description>
-        <dynamic_text frame="false" Halignment="AlignLeft" x="-17" y="152" z="1" rotation="0" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{4716c2f4-3f3a-441c-93c8-f90e91168538}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <rect ry="7" x="-30" y="-3" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="60" height="172" rx="7"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-17" y="152" z="2" rotation="0" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{4716c2f4-3f3a-441c-93c8-f90e91168538}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>EPP9001-0060</text>
         </dynamic_text>
         <text x="-25" y="151" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
@@ -66,10 +67,6 @@
         <circle x="9.97" y="21.48" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
         <circle x="10.97" y="16.53" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
         <circle x="15.92" y="21.48" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
-        <line end1="none" end2="none" y1="30.71" antialias="false" y2="3.11" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.96" length1="3" x2="-29.96" length2="3"/>
-        <line end1="none" end2="none" y1="133.71" antialias="false" y2="32.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.96" length1="3" x2="-29.96" length2="3"/>
-        <line end1="none" end2="none" y1="135.51" antialias="false" y2="163.11" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="30.04" length2="3"/>
-        <line end1="none" end2="none" y1="32.51" antialias="false" y2="133.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="30.04" length2="3"/>
         <line end1="none" end2="none" y1="135.51" antialias="false" y2="135.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.71" length1="3" x2="30.04" length2="3"/>
         <arc x="-21.61" y="-6.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="8" height="8" angle="45"/>
         <line end1="none" end2="none" y1="-0.06" antialias="false" y2="-1.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-14.78" length1="3" x2="-13.13" length2="3"/>
@@ -79,7 +76,6 @@
         <circle x="-6.96" y="9.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
         <line end1="none" end2="none" y1="133.71" antialias="false" y2="133.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="29.71" length2="3"/>
         <arc x="-14.3" y="-2.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
-        <rect ry="7" x="-30" y="-3" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="60" height="172" rx="7"/>
         <line end1="none" end2="none" y1="135" antialias="false" y2="135" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-30" length1="1.5" x2="-21" length2="1.5"/>
         <line end1="none" end2="none" y1="135" antialias="false" y2="131" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-21" length1="1.5" x2="-17" length2="1.5"/>
         <line end1="none" end2="none" y1="131" antialias="false" y2="131" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="17" length2="1.5"/>
@@ -96,12 +92,12 @@
         <text x="-25" y="50" font="Liberation Sans,7,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
         <text x="-13" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
         <polygon x6="-15" x7="-5" y1="60" antialias="false" y2="60" y3="85" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-5" y4="85" x2="5" y5="100" x3="5" y6="85" x4="15" y7="85" x5="0"/>
-        <dynamic_text frame="false" Halignment="AlignLeft" x="-29" y="-30" z="141" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-29" y="-30" z="88" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
             <text></text>
             <info_name>label</info_name>
         </dynamic_text>
-        <terminal type="Generic" x="20" y="20" name="X41" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
         <terminal type="Generic" x="-20" y="20" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
+        <terminal type="Generic" x="20" y="20" name="X41" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
         <terminal type="Generic" x="20" y="145" name="X61" uuid="{b98d1f74-22e9-4c81-973c-2919bd410049}" orientation="e"/>
     </description>
 </definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp9001-0060.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp9001-0060.elmt
@@ -1,0 +1,103 @@
+<definition type="element" link_type="simple" hotspot_x="35" hotspot_y="7" width="70" height="180" version="0.100.1">
+    <uuid uuid="{a23bc436-1060-47de-a432-64a4d86c8591}"/>
+    <names>
+        <name lang="de">EPP9001-0060 |1:1| EtherCAT P-/EtherCAT-Connector</name>
+        <name lang="en">EPP9001-0060 |1:1| EtherCAT P/EtherCAT connector</name>
+    </names>
+    <elementInformations/>
+    <informations>Author: Moritz Scholjegerdes</informations>
+    <description>
+        <text x="-25" y="151" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-17" y="152" z="1" rotation="0" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{4716c2f4-3f3a-441c-93c8-f90e91168538}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>EPP9001-0060</text>
+        </dynamic_text>
+        <text x="-20" y="110" font="Liberation Sans,7,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT"/>
+        <circle x="7.94" y="139.01" antialias="false" style="line-style:normal;line-weight:normal;filling:gray;color:black" diameter="12.2"/>
+        <text x="1" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="OUT"/>
+        <circle x="5.64" y="136.71" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.8"/>
+        <arc x="-21.61" y="164.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="54.5" width="8" height="8" angle="24.8125"/>
+        <circle x="17.44" y="-1.49" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="11.2"/>
+        <line end1="none" end2="none" y1="166.06" antialias="false" y2="167.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-14.78" length1="3" x2="-13.13" length2="3"/>
+        <arc x="-14.3" y="160.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="8" height="8" angle="-45"/>
+        <circle x="14.92" y="141.53" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="9.97" y="146.48" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <arc x="-29" y="155" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="0" width="12" height="12" angle="90"/>
+        <rect ry="0" x="-27" y="118" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <circle x="10.97" y="141.53" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="15.92" y="146.48" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <line end1="none" end2="none" y1="155" antialias="false" y2="155" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-23" length1="1.5" x2="-30" length2="1.5"/>
+        <circle x="-22.36" y="11.71" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.8"/>
+        <line end1="none" end2="none" y1="162" antialias="false" y2="164.86" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="-17" length2="1.5"/>
+        <arc x="13.61" y="-6.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="234.5" width="8" height="8" angle="24.8125"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="31.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-30" length1="1.5" x2="-21" length2="1.5"/>
+        <line end1="none" end2="none" y1="-0.06" antialias="false" y2="-1.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="14.78" length1="3" x2="13.13" length2="3"/>
+        <circle x="-28.56" y="156.51" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="11.2"/>
+        <arc x="6.3" y="-2.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="-45"/>
+        <circle x="-26" y="159" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="6"/>
+        <circle x="-20.06" y="14.01" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLRedRed;color:black" diameter="12.2"/>
+        <line end1="none" end2="none" y1="25.36" antialias="false" y2="24.41" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-15.99" length1="3" x2="-13.96" length2="3"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="35.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-21" length1="1.5" x2="-17" length2="1.5"/>
+        <circle x="16.04" y="122.41" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <line end1="none" end2="none" y1="24.41" antialias="false" y2="25.36" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-13.96" length1="3" x2="-11.92" length2="3"/>
+        <line end1="none" end2="none" y1="35.5" antialias="false" y2="35.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="31.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="30" length1="1.5" x2="21" length2="1.5"/>
+        <circle x="7.04" y="122.41" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="35.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="21" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="14.56" antialias="false" y2="15.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-13.18" length1="3" x2="-13.18" length2="3"/>
+        <arc x="-14.78" y="14.91" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="1.6" height="1.6" angle="180"/>
+        <line end1="none" end2="none" y1="15.71" antialias="false" y2="14.57" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-14.78" length1="3" x2="-14.78" length2="3"/>
+        <line end1="none" end2="none" y1="21.32" antialias="false" y2="20.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-13.36" length1="3" x2="-12.51" length2="3"/>
+        <line end1="none" end2="none" y1="22.71" antialias="false" y2="21.32" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-13.36" length1="3" x2="-13.36" length2="3"/>
+        <arc x="-14.56" y="22.11" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="1.2" height="1.2" angle="180"/>
+        <line end1="none" end2="none" y1="21.32" antialias="false" y2="22.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-14.56" length1="3" x2="-14.56" length2="3"/>
+        <line end1="none" end2="none" y1="20.61" antialias="false" y2="21.32" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-15.41" length1="3" x2="-14.56" length2="3"/>
+        <line end1="none" end2="none" y1="20.61" antialias="false" y2="20.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-16.26" length1="3" x2="-15.41" length2="3"/>
+        <arc x="-16.76" y="19.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="90" width="1" height="1" angle="180"/>
+        <line end1="none" end2="none" y1="19.61" antialias="false" y2="19.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-11.66" length1="3" x2="-16.26" length2="3"/>
+        <arc x="-12.16" y="19.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="270" width="1" height="1" angle="180"/>
+        <line end1="none" end2="none" y1="20.61" antialias="false" y2="20.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-12.51" length1="3" x2="-11.66" length2="3"/>
+        <circle x="-12.58" y="16.53" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-17.53" y="21.48" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-17.53" y="16.53" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="7.94" y="14.01" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGreenLimeGreen;color:black" diameter="12.2"/>
+        <circle x="-12.58" y="21.48" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="5.64" y="11.71" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.8"/>
+        <circle x="14.92" y="16.53" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="9.97" y="21.48" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="10.97" y="16.53" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="15.92" y="21.48" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <line end1="none" end2="none" y1="30.71" antialias="false" y2="3.11" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.96" length1="3" x2="-29.96" length2="3"/>
+        <line end1="none" end2="none" y1="133.71" antialias="false" y2="32.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.96" length1="3" x2="-29.96" length2="3"/>
+        <line end1="none" end2="none" y1="135.51" antialias="false" y2="163.11" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="30.04" length2="3"/>
+        <line end1="none" end2="none" y1="32.51" antialias="false" y2="133.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="30.04" length2="3"/>
+        <line end1="none" end2="none" y1="135.51" antialias="false" y2="135.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.71" length1="3" x2="30.04" length2="3"/>
+        <arc x="-21.61" y="-6.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="8" height="8" angle="45"/>
+        <line end1="none" end2="none" y1="-0.06" antialias="false" y2="-1.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-14.78" length1="3" x2="-13.13" length2="3"/>
+        <arc x="13.7" y="165.11" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
+        <circle x="2.04" y="9.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-2.46" y="26.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-6.96" y="9.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <line end1="none" end2="none" y1="133.71" antialias="false" y2="133.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="29.71" length2="3"/>
+        <arc x="-14.3" y="-2.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
+        <rect ry="7" x="-30" y="-3" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="60" height="172" rx="7"/>
+        <line end1="none" end2="none" y1="135" antialias="false" y2="135" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-30" length1="1.5" x2="-21" length2="1.5"/>
+        <line end1="none" end2="none" y1="135" antialias="false" y2="131" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-21" length1="1.5" x2="-17" length2="1.5"/>
+        <line end1="none" end2="none" y1="131" antialias="false" y2="131" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="135" antialias="false" y2="135" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="30" length1="1.5" x2="21" length2="1.5"/>
+        <line end1="none" end2="none" y1="135" antialias="false" y2="131" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="21" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="166.63" antialias="false" y2="168.63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="14.53" length1="3" x2="12.53" length2="3"/>
+        <line end1="none" end2="none" y1="165.13" antialias="false" y2="165.11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="28.94" length1="3" x2="18.51" length2="3"/>
+        <line end1="none" end2="none" y1="1.11" antialias="false" y2="1.11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.14" length1="3" x2="-17.61" length2="3"/>
+        <circle x="20" y="1" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="6"/>
+        <arc x="17" y="-1" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="180" width="12" height="12" angle="90"/>
+        <line end1="none" end2="none" y1="11" antialias="false" y2="11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="23" length1="1.5" x2="30" length2="1.5"/>
+        <line end1="none" end2="none" y1="4" antialias="false" y2="1.14" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="17" length1="1.5" x2="17" length2="1.5"/>
+        <text x="-13" y="166" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="BECKHOFF"/>
+        <text x="-25" y="50" font="Liberation Sans,7,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
+        <text x="-13" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
+        <polygon x6="-15" x7="-5" y1="60" antialias="false" y2="60" y3="85" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-5" y4="85" x2="5" y5="100" x3="5" y6="85" x4="15" y7="85" x5="0"/>
+        <terminal type="Generic" x="20" y="20" name="X40" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+        <terminal type="Generic" x="-20" y="20" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
+        <terminal type="Generic" x="20" y="145" name="Power" uuid="{b98d1f74-22e9-4c81-973c-2919bd410049}" orientation="e"/>
+    </description>
+</definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp9001-0060.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp9001-0060.elmt
@@ -1,5 +1,5 @@
 <definition type="element" link_type="simple" hotspot_x="35" hotspot_y="7" width="70" height="180" version="0.100.1">
-    <uuid uuid="{431bfa7f-7509-4562-a4ea-2d28978c6f07}"/>
+    <uuid uuid="{5140fd78-f6fa-4479-a610-73b5740c3b77}"/>
     <names>
         <name lang="de">EPP9001-0060 |1:1| EtherCAT P-/EtherCAT-Connector</name>
         <name lang="en">EPP9001-0060 |1:1| EtherCAT P/EtherCAT connector</name>
@@ -96,8 +96,11 @@
             <text></text>
             <info_name>label</info_name>
         </dynamic_text>
-        <terminal type="Generic" x="-20" y="20" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="114.5" z="125" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
         <terminal type="Generic" x="20" y="20" name="X41" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
         <terminal type="Generic" x="20" y="145" name="X61" uuid="{b98d1f74-22e9-4c81-973c-2919bd410049}" orientation="e"/>
+        <terminal type="Generic" x="-20" y="20" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
     </description>
 </definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp9001-0060.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp9001-0060.elmt
@@ -1,5 +1,5 @@
 <definition type="element" link_type="simple" hotspot_x="35" hotspot_y="7" width="70" height="180" version="0.100.1">
-    <uuid uuid="{a23bc436-1060-47de-a432-64a4d86c8591}"/>
+    <uuid uuid="{4ba262e6-96d6-4476-92a8-27d55d70af38}"/>
     <names>
         <name lang="de">EPP9001-0060 |1:1| EtherCAT P-/EtherCAT-Connector</name>
         <name lang="en">EPP9001-0060 |1:1| EtherCAT P/EtherCAT connector</name>
@@ -7,10 +7,10 @@
     <elementInformations/>
     <informations>Author: Moritz Scholjegerdes</informations>
     <description>
-        <text x="-25" y="151" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
         <dynamic_text frame="false" Halignment="AlignLeft" x="-17" y="152" z="1" rotation="0" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{4716c2f4-3f3a-441c-93c8-f90e91168538}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>EPP9001-0060</text>
         </dynamic_text>
+        <text x="-25" y="151" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
         <text x="-20" y="110" font="Liberation Sans,7,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT"/>
         <circle x="7.94" y="139.01" antialias="false" style="line-style:normal;line-weight:normal;filling:gray;color:black" diameter="12.2"/>
         <text x="1" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="OUT"/>
@@ -96,8 +96,12 @@
         <text x="-25" y="50" font="Liberation Sans,7,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
         <text x="-13" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
         <polygon x6="-15" x7="-5" y1="60" antialias="false" y2="60" y3="85" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-5" y4="85" x2="5" y5="100" x3="5" y6="85" x4="15" y7="85" x5="0"/>
-        <terminal type="Generic" x="20" y="20" name="X40" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-29" y="-30" z="141" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
+            <text></text>
+            <info_name>label</info_name>
+        </dynamic_text>
+        <terminal type="Generic" x="20" y="20" name="X41" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
         <terminal type="Generic" x="-20" y="20" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
-        <terminal type="Generic" x="20" y="145" name="Power" uuid="{b98d1f74-22e9-4c81-973c-2919bd410049}" orientation="e"/>
+        <terminal type="Generic" x="20" y="145" name="X61" uuid="{b98d1f74-22e9-4c81-973c-2919bd410049}" orientation="e"/>
     </description>
 </definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp9001-0060_x2.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp9001-0060_x2.elmt
@@ -1,5 +1,5 @@
 <definition type="element" link_type="simple" hotspot_x="65" hotspot_y="9" width="130" height="350" version="0.100.1">
-    <uuid uuid="{56a34ae1-19ab-4364-8e5d-eff92665da62}"/>
+    <uuid uuid="{d7ae7bfb-740f-4a63-959b-dd109363f596}"/>
     <names>
         <name lang="de">EPP9001-0060 |2:1| EtherCAT P/EtherCAT Connector</name>
         <name lang="en">EPP9001-0060 |2:1| EtherCAT P/EtherCAT connector</name>
@@ -92,16 +92,20 @@
         <arc x="34" y="-2" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="180" width="24" height="24" angle="90"/>
         <line end1="none" end2="none" y1="22" antialias="false" y2="22" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="46" length1="3" x2="60" length2="3"/>
         <line end1="none" end2="none" y1="9" antialias="false" y2="2.28" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="34" length1="3" x2="34" length2="3"/>
-        <dynamic_text frame="false" Halignment="AlignLeft" x="-34" y="312" z="117" rotation="0" font="Liberation Sans,8,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{b5ec55a8-7f78-1b91-4ada-ed2333c17cda}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
-            <text>EPP9001-00060</text>
-            <info_name>designation</info_name>
-        </dynamic_text>
         <text x="-25" y="335" font="Liberation Sans,7,-1,5,75,0,0,0,0,0,Bold" rotation="0" color="#000000" text="BECKHOFF"/>
         <text x="-26" y="13" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
         <rect ry="14" x="-60" y="-5.96" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="120" height="344" rx="14"/>
         <polygon x6="-30" x7="-10" x8="-10" x9="-10" closed="false" y1="116" y2="116" y3="166" y4="166" y5="196" y6="166" x1="-10" y7="166" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="10" y8="116" antialias="false" x3="10" y9="116" x4="30" x5="0"/>
-        <terminal type="Generic" x="40" y="40" name="X40" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-34" y="312" z="117" rotation="0" font="Liberation Sans,8,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{b5ec55a8-7f78-1b91-4ada-ed2333c17cda}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
+            <text>EPP9001-00060</text>
+            <info_name>designation</info_name>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-49" y="-36" z="141" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
+            <text></text>
+            <info_name>label</info_name>
+        </dynamic_text>
+        <terminal type="Generic" x="40" y="40" name="X41" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
         <terminal type="Generic" x="-40" y="40" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
-        <terminal type="Generic" x="40" y="290" name="X40" uuid="{af489b28-2130-48b4-bd68-08278510a914}" orientation="e"/>
+        <terminal type="Generic" x="40" y="290" name="X61" uuid="{af489b28-2130-48b4-bd68-08278510a914}" orientation="e"/>
     </description>
 </definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp9001-0060_x2.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp9001-0060_x2.elmt
@@ -1,5 +1,5 @@
 <definition type="element" link_type="simple" hotspot_x="65" hotspot_y="9" width="130" height="350" version="0.100.1">
-    <uuid uuid="{52c634ef-9bf8-4d9d-a021-581b60a6b2e3}"/>
+    <uuid uuid="{0f9f59c0-6a13-4537-947f-bf71ea271c8e}"/>
     <names>
         <name lang="de">EPP9001-0060 |2:1| EtherCAT P/EtherCAT Connector</name>
         <name lang="en">EPP9001-0060 |2:1| EtherCAT P/EtherCAT connector</name>
@@ -100,8 +100,11 @@
             <text></text>
             <info_name>label</info_name>
         </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38" y="234.5" z="120" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
         <terminal type="Generic" x="40" y="40" name="X41" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
-        <terminal type="Generic" x="-40" y="40" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
         <terminal type="Generic" x="40" y="290" name="X61" uuid="{af489b28-2130-48b4-bd68-08278510a914}" orientation="e"/>
+        <terminal type="Generic" x="-40" y="40" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
     </description>
 </definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp9001-0060_x2.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp9001-0060_x2.elmt
@@ -1,5 +1,5 @@
 <definition type="element" link_type="simple" hotspot_x="65" hotspot_y="9" width="130" height="350" version="0.100.1">
-    <uuid uuid="{d7ae7bfb-740f-4a63-959b-dd109363f596}"/>
+    <uuid uuid="{52c634ef-9bf8-4d9d-a021-581b60a6b2e3}"/>
     <names>
         <name lang="de">EPP9001-0060 |2:1| EtherCAT P/EtherCAT Connector</name>
         <name lang="en">EPP9001-0060 |2:1| EtherCAT P/EtherCAT connector</name>
@@ -10,6 +10,7 @@
     </elementInformations>
     <informations>Author: Moritz Scholjegerdes</informations>
     <description>
+        <rect ry="14" x="-60" y="-5.96" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="120" height="344" rx="14"/>
         <circle x="15.88" y="278" antialias="false" style="line-style:normal;line-weight:normal;filling:gray;color:black" diameter="24.4"/>
         <text x="-50" y="102" font="Liberation Sans,14,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
         <text x="-43" y="223" font="Liberation Sans,14,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT"/>
@@ -67,10 +68,6 @@
         <circle x="19.94" y="43" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
         <circle x="21.94" y="33.06" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
         <circle x="31.84" y="43" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
-        <line end1="none" end2="none" y1="61.42" antialias="false" y2="6.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-59.92" length1="6" x2="-59.92" length2="6"/>
-        <line end1="none" end2="none" y1="267.42" antialias="false" y2="65" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-59.92" length1="6" x2="-59.92" length2="6"/>
-        <line end1="none" end2="none" y1="271" antialias="false" y2="326.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="60.08" length2="6"/>
-        <line end1="none" end2="none" y1="65" antialias="false" y2="267.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="60.08" length2="6"/>
         <line end1="none" end2="none" y1="271" antialias="false" y2="271" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="59.42" length1="6" x2="60.08" length2="6"/>
         <arc x="-43.22" y="-13.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="16" height="16" angle="45"/>
         <line end1="none" end2="none" y1="-0.12" antialias="false" y2="-3.44" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.56" length1="6" x2="-26.26" length2="6"/>
@@ -94,13 +91,12 @@
         <line end1="none" end2="none" y1="9" antialias="false" y2="2.28" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="34" length1="3" x2="34" length2="3"/>
         <text x="-25" y="335" font="Liberation Sans,7,-1,5,75,0,0,0,0,0,Bold" rotation="0" color="#000000" text="BECKHOFF"/>
         <text x="-26" y="13" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
-        <rect ry="14" x="-60" y="-5.96" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="120" height="344" rx="14"/>
         <polygon x6="-30" x7="-10" x8="-10" x9="-10" closed="false" y1="116" y2="116" y3="166" y4="166" y5="196" y6="166" x1="-10" y7="166" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="10" y8="116" antialias="false" x3="10" y9="116" x4="30" x5="0"/>
-        <dynamic_text frame="false" Halignment="AlignLeft" x="-34" y="312" z="117" rotation="0" font="Liberation Sans,8,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{b5ec55a8-7f78-1b91-4ada-ed2333c17cda}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-34" y="312" z="87" rotation="0" font="Liberation Sans,8,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{b5ec55a8-7f78-1b91-4ada-ed2333c17cda}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
             <text>EPP9001-00060</text>
             <info_name>designation</info_name>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignLeft" x="-49" y="-36" z="141" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-49" y="-36" z="88" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
             <text></text>
             <info_name>label</info_name>
         </dynamic_text>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp9001-0060_x2.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp9001-0060_x2.elmt
@@ -1,0 +1,107 @@
+<definition type="element" link_type="simple" hotspot_x="65" hotspot_y="9" width="130" height="350" version="0.100.1">
+    <uuid uuid="{56a34ae1-19ab-4364-8e5d-eff92665da62}"/>
+    <names>
+        <name lang="de">EPP9001-0060 |2:1| EtherCAT P/EtherCAT Connector</name>
+        <name lang="en">EPP9001-0060 |2:1| EtherCAT P/EtherCAT connector</name>
+    </names>
+    <elementInformations>
+        <elementInformation name="designation" show="1">EPP9001-00060</elementInformation>
+        <elementInformation name="manufacturer" show="1">Beckhoff</elementInformation>
+    </elementInformations>
+    <informations>Author: Moritz Scholjegerdes</informations>
+    <description>
+        <circle x="15.88" y="278" antialias="false" style="line-style:normal;line-weight:normal;filling:gray;color:black" diameter="24.4"/>
+        <text x="-50" y="102" font="Liberation Sans,14,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
+        <text x="-43" y="223" font="Liberation Sans,14,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT"/>
+        <text x="-55" y="302" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
+        <text x="2" y="13" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="OUT"/>
+        <circle x="11.28" y="273.42" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
+        <arc x="-43.22" y="329.98" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="51.4375" width="16" height="16" angle="28.5"/>
+        <circle x="34.88" y="-3" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="22.4"/>
+        <circle x="29.84" y="283.06" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="19.94" y="293" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="21.94" y="283.06" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <line end1="none" end2="none" y1="332.32" antialias="false" y2="335.64" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.56" length1="6" x2="-26.26" length2="6"/>
+        <arc x="-28.6" y="321.98" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="225" width="16" height="16" angle="45"/>
+        <circle x="31.84" y="293" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <arc x="-58" y="310" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="0" width="24" height="24" angle="90"/>
+        <rect ry="0" x="-54" y="236" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <line end1="none" end2="none" y1="310" antialias="false" y2="310" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-46" length1="3" x2="-60" length2="3"/>
+        <circle x="-44.72" y="23.42" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
+        <line end1="none" end2="none" y1="322.94" antialias="false" y2="329.92" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="-34" length2="3"/>
+        <arc x="27.22" y="-13.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="231.25" width="16" height="16" angle="28.6875"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-60" length1="3" x2="-42" length2="3"/>
+        <line end1="none" end2="none" y1="-0.12" antialias="false" y2="-3.44" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="29.56" length1="6" x2="26.26" length2="6"/>
+        <circle x="-57.12" y="313" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="22.4"/>
+        <arc x="12.6" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="45" width="16" height="16" angle="45"/>
+        <circle x="-52" y="318" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="12"/>
+        <circle x="-40.12" y="28" antialias="false" style="line-style:normal;line-weight:normal;filling:red;color:black" diameter="24.4"/>
+        <line end1="none" end2="none" y1="51.29" antialias="false" y2="48.82" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-32" length1="6" x2="-27.92" length2="6"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="71" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-42" length1="3" x2="-34" length2="3"/>
+        <circle x="32.08" y="244.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <line end1="none" end2="none" y1="48.82" antialias="false" y2="51.29" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-27.92" length1="6" x2="-23.84" length2="6"/>
+        <line end1="none" end2="none" y1="71" antialias="false" y2="71" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="60" length1="3" x2="42" length2="3"/>
+        <circle x="14.08" y="244.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="71" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="42" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="28" antialias="false" y2="31.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-26.36" length1="6" x2="-26.36" length2="6"/>
+        <arc x="-29.56" y="29.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="3.2" height="3.2" angle="180"/>
+        <line end1="none" end2="none" y1="31.42" antialias="false" y2="28.03" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.56" length1="6" x2="-29.56" length2="6"/>
+        <line end1="none" end2="none" y1="42.64" antialias="false" y2="41.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-26.72" length1="6" x2="-25" length2="6"/>
+        <line end1="none" end2="none" y1="45.42" antialias="false" y2="42.64" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-26.72" length1="6" x2="-26.72" length2="6"/>
+        <arc x="-29.12" y="44.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="2.4" height="2.4" angle="180"/>
+        <line end1="none" end2="none" y1="42.64" antialias="false" y2="45.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.12" length1="6" x2="-29.12" length2="6"/>
+        <line end1="none" end2="none" y1="41.22" antialias="false" y2="42.64" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-30.82" length1="6" x2="-29.12" length2="6"/>
+        <line end1="none" end2="none" y1="41.22" antialias="false" y2="41.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-32.52" length1="6" x2="-30.82" length2="6"/>
+        <arc x="-33.52" y="39.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="90" width="2" height="2" angle="180"/>
+        <line end1="none" end2="none" y1="39.22" antialias="false" y2="39.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-23.32" length1="6" x2="-32.52" length2="6"/>
+        <arc x="-24.32" y="39.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="270" width="2" height="2" angle="180"/>
+        <line end1="none" end2="none" y1="41.22" antialias="false" y2="41.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-25" length1="6" x2="-23.32" length2="6"/>
+        <circle x="-25.16" y="33.06" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-35.06" y="43" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-35.06" y="33.06" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="15.88" y="28" antialias="false" style="line-style:normal;line-weight:normal;filling:HTMLGreenLimeGreen;color:black" diameter="24.4"/>
+        <circle x="-25.16" y="43" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="11.28" y="23.42" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
+        <circle x="29.84" y="33.06" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="19.94" y="43" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="21.94" y="33.06" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="31.84" y="43" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <line end1="none" end2="none" y1="61.42" antialias="false" y2="6.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-59.92" length1="6" x2="-59.92" length2="6"/>
+        <line end1="none" end2="none" y1="267.42" antialias="false" y2="65" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-59.92" length1="6" x2="-59.92" length2="6"/>
+        <line end1="none" end2="none" y1="271" antialias="false" y2="326.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="60.08" length2="6"/>
+        <line end1="none" end2="none" y1="65" antialias="false" y2="267.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="60.08" length2="6"/>
+        <line end1="none" end2="none" y1="271" antialias="false" y2="271" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="59.42" length1="6" x2="60.08" length2="6"/>
+        <arc x="-43.22" y="-13.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="16" height="16" angle="45"/>
+        <line end1="none" end2="none" y1="-0.12" antialias="false" y2="-3.44" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.56" length1="6" x2="-26.26" length2="6"/>
+        <arc x="27.4" y="330.22" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="16" height="16" angle="45"/>
+        <circle x="4" y="17.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-4.92" y="53.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-14" y="17.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <line end1="none" end2="none" y1="267.42" antialias="false" y2="267.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="59.42" length2="6"/>
+        <arc x="-28.6" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="16" height="16" angle="45"/>
+        <line end1="none" end2="none" y1="270" antialias="false" y2="270" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-60" length1="3" x2="-42" length2="3"/>
+        <line end1="none" end2="none" y1="270" antialias="false" y2="262" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-42" length1="3" x2="-34" length2="3"/>
+        <line end1="none" end2="none" y1="262" antialias="false" y2="262" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="270" antialias="false" y2="270" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="60" length1="3" x2="42" length2="3"/>
+        <line end1="none" end2="none" y1="270" antialias="false" y2="262" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="42" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="333.26" antialias="false" y2="337.26" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="29.06" length1="6" x2="25.06" length2="6"/>
+        <line end1="none" end2="none" y1="330.26" antialias="false" y2="330.23" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="57.88" length1="6" x2="36.02" length2="6"/>
+        <line end1="none" end2="none" y1="2.22" antialias="false" y2="2.22" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-58.28" length1="6" x2="-35.22" length2="6"/>
+        <circle x="40" y="2" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="12"/>
+        <arc x="34" y="-2" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="180" width="24" height="24" angle="90"/>
+        <line end1="none" end2="none" y1="22" antialias="false" y2="22" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="46" length1="3" x2="60" length2="3"/>
+        <line end1="none" end2="none" y1="9" antialias="false" y2="2.28" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="34" length1="3" x2="34" length2="3"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-34" y="312" z="117" rotation="0" font="Liberation Sans,8,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{b5ec55a8-7f78-1b91-4ada-ed2333c17cda}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
+            <text>EPP9001-00060</text>
+            <info_name>designation</info_name>
+        </dynamic_text>
+        <text x="-25" y="335" font="Liberation Sans,7,-1,5,75,0,0,0,0,0,Bold" rotation="0" color="#000000" text="BECKHOFF"/>
+        <text x="-26" y="13" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
+        <rect ry="14" x="-60" y="-5.96" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="120" height="344" rx="14"/>
+        <polygon x6="-30" x7="-10" x8="-10" x9="-10" closed="false" y1="116" y2="116" y3="166" y4="166" y5="196" y6="166" x1="-10" y7="166" style="line-style:normal;line-weight:normal;filling:none;color:black" x2="10" y8="116" antialias="false" x3="10" y9="116" x4="30" x5="0"/>
+        <terminal type="Generic" x="40" y="40" name="X40" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+        <terminal type="Generic" x="-40" y="40" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
+        <terminal type="Generic" x="40" y="290" name="X40" uuid="{af489b28-2130-48b4-bd68-08278510a914}" orientation="e"/>
+    </description>
+</definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_126x30_2km.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_126x30_2km.elmt
@@ -1,0 +1,193 @@
+<definition type="element" link_type="simple" hotspot_x="35" hotspot_y="6" width="70" height="260" version="0.100.1">
+    <uuid uuid="{2f67e092-f1fc-43ba-a380-32a0158859af}"/>
+    <names>
+        <name lang="de">EPPxxxx |1:1| 126,5x30mm | IP20-Stecker</name>
+        <name lang="en">EPPxxxx |1:1| 126.5x30mm | IP20 connector</name>
+    </names>
+    <elementInformations>
+        <elementInformation name="designation" show="1">EPP2339-0003</elementInformation>
+        <elementInformation name="manufacturer" show="1">Beckhoff</elementInformation>
+    </elementInformations>
+    <informations>Author: Moritz Scholjegerdes</informations>
+    <description>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="35.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-21" length1="1.5" x2="-17" length2="1.5"/>
+        <rect ry="0" x="9.9" y="168.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="7" x="-30" y="-3" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="60" height="253" rx="7"/>
+        <rect ry="0" x="9.9" y="196.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <line end1="none" end2="none" y1="124.05" antialias="false" y2="124.05" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="25.9" length1="1.5" x2="19.9" length2="1.5"/>
+        <rect ry="0" x="9.9" y="189.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="9.9" y="133.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <text x="1" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="OUT"/>
+        <rect ry="0" x="9.9" y="175.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="9.9" y="91.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <text x="17.9" y="136.05" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="Up1"/>
+        <circle x="4.4" y="125.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5"/>
+        <rect ry="0" x="9.9" y="140.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="9.9" y="112.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="9.9" y="161.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="9.9" y="182.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="1.9" y="187.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="9.9" y="147.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <arc x="-21.61" y="245.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="54.5" width="8" height="8" angle="24.8125"/>
+        <rect ry="0" x="1.9" y="173.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="4.4" y="189.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="9.9" y="84.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="1.9" y="131.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <circle x="17.44" y="-1.49" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="11.2"/>
+        <rect ry="0" x="1.9" y="159.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="4.4" y="175.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <circle x="4.4" y="41.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5"/>
+        <rect ry="0" x="4.4" y="133.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="9.9" y="154.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="1.9" y="180.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="9.9" y="105.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="1.9" y="138.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <line end1="none" end2="none" y1="247.06" antialias="false" y2="248.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-14.78" length1="3" x2="-13.13" length2="3"/>
+        <rect ry="0" x="1.9" y="145.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="9.9" y="49.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="4.4" y="140.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <arc x="-14.3" y="241.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="8" height="8" angle="-45"/>
+        <rect ry="0" x="4.4" y="182.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="4.4" y="161.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="1.9" y="103.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="4.4" y="147.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="9.9" y="77.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="1.9" y="152.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="9.9" y="98.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="9.9" y="56.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="4.4" y="154.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <arc x="-29" y="236" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="0" width="12" height="12" angle="90"/>
+        <rect ry="0" x="1.9" y="166.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="9.9" y="63.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="-27" y="199" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <rect ry="0" x="1.9" y="89.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="4.4" y="168.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="4.4" y="105.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <line end1="none" end2="none" y1="236" antialias="false" y2="236" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-23" length1="1.5" x2="-30" length2="1.5"/>
+        <rect ry="0" x="1.9" y="47.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="1.9" y="75.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="4.4" y="91.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="4.4" y="49.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <circle x="-22.36" y="11.71" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.8"/>
+        <rect ry="0" x="9.9" y="70.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="1.9" y="96.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="1.9" y="54.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <line end1="none" end2="none" y1="243" antialias="false" y2="245.86" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="-17" length2="1.5"/>
+        <rect ry="0" x="4.4" y="56.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="1.9" y="61.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="4.4" y="98.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <arc x="13.61" y="-6.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="234.5" width="8" height="8" angle="24.8125"/>
+        <rect ry="0" x="4.4" y="77.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="4.4" y="63.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="1.9" y="68.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="31.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-30" length1="1.5" x2="-21" length2="1.5"/>
+        <rect ry="0" x="4.4" y="70.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="1.9" y="82.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="4.4" y="84.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <rect ry="0" x="-2.1" y="40.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="18" height="84" rx="0"/>
+        <line end1="none" end2="none" y1="-0.06" antialias="false" y2="-1.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="14.78" length1="3" x2="13.13" length2="3"/>
+        <circle x="4.4" y="118.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5"/>
+        <circle x="-28.56" y="237.51" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="11.2"/>
+        <rect ry="0" x="1.9" y="110.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="4.4" y="112.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <arc x="6.3" y="-2.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="-45"/>
+        <circle x="-22.06" y="177.46" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-22.06" y="185.46" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-26" y="240" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="6"/>
+        <rect ry="0" x="-2.1" y="124.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="18" height="84" rx="0"/>
+        <circle x="4.4" y="202.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5"/>
+        <rect ry="0" x="1.9" y="194.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="8" height="7" rx="0"/>
+        <rect ry="0" x="4.4" y="196.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="3" height="3" rx="0"/>
+        <circle x="-20.06" y="14.01" antialias="false" style="line-style:normal;line-weight:normal;filling:red;color:black" diameter="12.2"/>
+        <text x="17.9" y="52.05" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="Up1"/>
+        <line end1="none" end2="none" y1="124.05" antialias="false" y2="124.05" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-11.1" length1="1.5" x2="-25.1" length2="1.5"/>
+        <line end1="none" end2="none" y1="25.36" antialias="false" y2="24.41" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-15.99" length1="3" x2="-13.96" length2="3"/>
+        <line end1="none" end2="none" y1="24.41" antialias="false" y2="25.36" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-13.96" length1="3" x2="-11.92" length2="3"/>
+        <line end1="none" end2="none" y1="35.5" antialias="false" y2="35.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="31.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="30" length1="1.5" x2="21" length2="1.5"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="35.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="21" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="14.56" antialias="false" y2="15.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-13.18" length1="3" x2="-13.18" length2="3"/>
+        <arc x="-14.78" y="14.91" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="1.6" height="1.6" angle="180"/>
+        <line end1="none" end2="none" y1="15.71" antialias="false" y2="14.57" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-14.78" length1="3" x2="-14.78" length2="3"/>
+        <line end1="none" end2="none" y1="21.32" antialias="false" y2="20.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-13.36" length1="3" x2="-12.51" length2="3"/>
+        <line end1="none" end2="none" y1="22.71" antialias="false" y2="21.32" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-13.36" length1="3" x2="-13.36" length2="3"/>
+        <arc x="-14.56" y="22.11" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="1.2" height="1.2" angle="180"/>
+        <line end1="none" end2="none" y1="21.32" antialias="false" y2="22.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-14.56" length1="3" x2="-14.56" length2="3"/>
+        <line end1="none" end2="none" y1="20.61" antialias="false" y2="21.32" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-15.41" length1="3" x2="-14.56" length2="3"/>
+        <line end1="none" end2="none" y1="20.61" antialias="false" y2="20.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-16.26" length1="3" x2="-15.41" length2="3"/>
+        <arc x="-16.76" y="19.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="90" width="1" height="1" angle="180"/>
+        <line end1="none" end2="none" y1="19.61" antialias="false" y2="19.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-11.66" length1="3" x2="-16.26" length2="3"/>
+        <arc x="-12.16" y="19.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="270" width="1" height="1" angle="180"/>
+        <line end1="none" end2="none" y1="20.61" antialias="false" y2="20.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-12.51" length1="3" x2="-11.66" length2="3"/>
+        <circle x="-12.58" y="16.53" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-17.53" y="21.48" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-17.53" y="16.53" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="7.94" y="14.01" antialias="false" style="line-style:normal;line-weight:normal;filling:red;color:black" diameter="12.2"/>
+        <circle x="-12.58" y="21.48" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="5.64" y="11.71" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.8"/>
+        <line end1="none" end2="none" y1="25.36" antialias="false" y2="24.41" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="12.01" length1="3" x2="14.04" length2="3"/>
+        <line end1="none" end2="none" y1="24.41" antialias="false" y2="25.36" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="14.04" length1="3" x2="16.08" length2="3"/>
+        <line end1="none" end2="none" y1="14.56" antialias="false" y2="15.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="14.82" length1="3" x2="14.82" length2="3"/>
+        <arc x="13.22" y="14.91" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="1.6" height="1.6" angle="180"/>
+        <line end1="none" end2="none" y1="15.71" antialias="false" y2="14.57" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="13.22" length1="3" x2="13.22" length2="3"/>
+        <line end1="none" end2="none" y1="21.32" antialias="false" y2="20.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="14.64" length1="3" x2="15.49" length2="3"/>
+        <line end1="none" end2="none" y1="22.71" antialias="false" y2="21.32" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="14.64" length1="3" x2="14.64" length2="3"/>
+        <arc x="13.44" y="22.11" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="1.2" height="1.2" angle="180"/>
+        <line end1="none" end2="none" y1="21.32" antialias="false" y2="22.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="13.44" length1="3" x2="13.44" length2="3"/>
+        <line end1="none" end2="none" y1="20.61" antialias="false" y2="21.32" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="12.59" length1="3" x2="13.44" length2="3"/>
+        <line end1="none" end2="none" y1="20.61" antialias="false" y2="20.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="11.74" length1="3" x2="12.59" length2="3"/>
+        <arc x="11.24" y="19.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="90" width="1" height="1" angle="180"/>
+        <line end1="none" end2="none" y1="19.61" antialias="false" y2="19.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="16.34" length1="3" x2="11.74" length2="3"/>
+        <arc x="15.84" y="19.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="270" width="1" height="1" angle="180"/>
+        <line end1="none" end2="none" y1="20.61" antialias="false" y2="20.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="15.49" length1="3" x2="16.34" length2="3"/>
+        <circle x="15.42" y="16.53" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="10.47" y="21.48" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="10.47" y="16.53" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="15.42" y="21.48" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-17" y="233" z="120" rotation="0" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{4716c2f4-3f3a-441c-93c8-f90e91168538}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
+            <text>EPP2339-0003</text>
+            <info_name>designation</info_name>
+        </dynamic_text>
+        <line end1="none" end2="none" y1="135.51" antialias="false" y2="135.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.71" length1="3" x2="30.04" length2="3"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="195.4" z="125" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <arc x="-21.61" y="-6.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="8" height="8" angle="45"/>
+        <line end1="none" end2="none" y1="-0.06" antialias="false" y2="-1.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-14.78" length1="3" x2="-13.13" length2="3"/>
+        <arc x="13.7" y="246.11" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
+        <circle x="2" y="9.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-2.5" y="26.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-7" y="9.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <line end1="none" end2="none" y1="133.71" antialias="false" y2="133.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="29.71" length2="3"/>
+        <arc x="-14.3" y="-2.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-29" y="-30" z="139" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
+            <text></text>
+            <info_name>label</info_name>
+        </dynamic_text>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="216" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-30" length1="1.5" x2="-21" length2="1.5"/>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-21" length1="1.5" x2="-17" length2="1.5"/>
+        <line end1="none" end2="none" y1="212" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="216" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="30" length1="1.5" x2="21" length2="1.5"/>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="21" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="247.63" antialias="false" y2="249.63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="14.53" length1="3" x2="12.53" length2="3"/>
+        <line end1="none" end2="none" y1="246.13" antialias="false" y2="246.11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="28.94" length1="3" x2="18.51" length2="3"/>
+        <dynamic_text frame="false" Halignment="AlignRight" x="-30.1" y="64.05" z="147" rotation="270" font="Liberation Sans,7,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{01f2e6c3-3612-4601-89fd-8a5cd8c0eedf}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>DIO</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignRight" x="-30.1" y="149.05" z="147" rotation="270" font="Liberation Sans,7,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{01f2e6c3-3612-4601-89fd-8a5cd8c0eedf}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>DIO</text>
+        </dynamic_text>
+        <line end1="none" end2="none" y1="1.11" antialias="false" y2="1.11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.14" length1="3" x2="-17.61" length2="3"/>
+        <circle x="20" y="1" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="6"/>
+        <arc x="17" y="-1" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="180" width="12" height="12" angle="90"/>
+        <line end1="none" end2="none" y1="11" antialias="false" y2="11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="23" length1="1.5" x2="30" length2="1.5"/>
+        <line end1="none" end2="none" y1="4" antialias="false" y2="1.14" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="17" length1="1.5" x2="17" length2="1.5"/>
+        <text x="-13" y="247" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="BECKHOFF"/>
+        <text x="-26" y="233" font="Liberation Sans,7,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
+        <text x="-13" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
+        <terminal type="Generic" x="-20" y="20" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
+        <terminal type="Generic" x="20" y="20" name="X51" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+        <terminal type="Generic" x="19.9" y="166.05" name="" uuid="{3ea3151c-a17c-4e23-a82f-cb3c6e438fbe}" orientation="e"/>
+        <terminal type="Generic" x="19.9" y="82.05" name="" uuid="{f36f9892-e9cd-4c46-bf23-044db8ebdce8}" orientation="e"/>
+    </description>
+</definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_126x30_2km_2x.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_126x30_2km_2x.elmt
@@ -1,0 +1,194 @@
+<definition type="element" link_type="simple" hotspot_x="65" hotspot_y="8" width="130" height="510" version="0.100.1">
+    <uuid uuid="{3ee1eed9-eaef-42d5-9b9c-b523c879df49}"/>
+    <names>
+        <name lang="de">EPPxxxx |2:1| 126,5x30mm | IP20-Stecker</name>
+        <name lang="en">EPPxxxx |2:1| 126.5x30mm | IP20 connector</name>
+    </names>
+    <elementInformations>
+        <elementInformation name="designation" show="1">EPP2339-0003</elementInformation>
+        <elementInformation name="manufacturer" show="1">Beckhoff</elementInformation>
+    </elementInformations>
+    <informations>Author: Moritz Scholjegerdes</informations>
+    <description>
+        <rect ry="14" x="-60" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="120" height="506" rx="14"/>
+        <rect ry="0" x="20.71" y="336.49" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="20.71" y="392.29" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <line end1="none" end2="none" y1="248.81" antialias="false" y2="248.81" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="51.79" length1="1.5" x2="40.14" length2="1.5"/>
+        <rect ry="0" x="20.71" y="378.33" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="20.71" y="266.74" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="20.71" y="350.43" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <text x="2" y="13" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="OUT"/>
+        <rect ry="0" x="20.71" y="183.04" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <text x="36.25" y="269.71" font="Liberation Sans,6,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="Up1"/>
+        <ellipse x="10.03" y="250.8" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="9.71" height="9.96"/>
+        <rect ry="0" x="20.71" y="280.68" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="20.71" y="224.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="20.71" y="322.53" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <arc x="-43.22" y="492.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="51.4375" width="16" height="16" angle="28.5"/>
+        <rect ry="0" x="20.71" y="364.39" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="5.17" y="374.35" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="20.71" y="294.64" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <circle x="-45.99" y="370.02" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <rect ry="0" x="5.17" y="346.45" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="10.03" y="378.33" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="20.71" y="169.09" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <circle x="34.88" y="-3" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="22.4"/>
+        <rect ry="0" x="5.17" y="262.76" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="5.17" y="318.55" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="10.03" y="350.43" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <ellipse x="10.03" y="83.39" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="9.71" height="9.96"/>
+        <rect ry="0" x="10.03" y="266.74" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="20.71" y="308.58" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <line end1="none" end2="none" y1="494.42" antialias="false" y2="497.74" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.56" length1="6" x2="-26.26" length2="6"/>
+        <rect ry="0" x="5.17" y="360.41" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="20.71" y="210.94" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="5.17" y="276.7" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="5.17" y="290.65" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <arc x="-28.6" y="484.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="225" width="16" height="16" angle="45"/>
+        <rect ry="0" x="20.71" y="99.34" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="10.03" y="280.68" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="10.03" y="364.39" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="10.03" y="322.53" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="5.17" y="206.95" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="10.03" y="294.64" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="20.71" y="155.14" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="5.17" y="304.6" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="20.71" y="196.99" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="20.71" y="113.29" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <arc x="-58" y="472.3" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="0" width="24" height="24" angle="90"/>
+        <rect ry="0" x="-54" y="396" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <rect ry="0" x="10.03" y="308.58" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="5.17" y="332.51" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="20.71" y="127.24" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <line end1="none" end2="none" y1="472.3" antialias="false" y2="472.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-46" length1="3" x2="-60" length2="3"/>
+        <rect ry="0" x="5.17" y="179.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="10.03" y="336.49" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="10.03" y="210.94" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="5.17" y="95.35" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="5.17" y="151.15" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <circle x="-44.72" y="23.42" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
+        <rect ry="0" x="10.03" y="183.04" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <line end1="none" end2="none" y1="485.04" antialias="false" y2="492.02" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="-34" length2="3"/>
+        <rect ry="0" x="10.03" y="99.34" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="20.71" y="141.19" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="5.17" y="193" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="5.17" y="109.3" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="10.03" y="113.29" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <arc x="27.22" y="-13.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="231.25" width="16" height="16" angle="28.6875"/>
+        <rect ry="0" x="5.17" y="123.25" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="10.03" y="196.99" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-60" length1="3" x2="-42" length2="3"/>
+        <rect ry="0" x="10.03" y="155.14" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="10.03" y="127.24" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="5.17" y="137.2" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <line end1="none" end2="none" y1="-0.12" antialias="false" y2="-3.44" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="29.56" length1="6" x2="26.26" length2="6"/>
+        <rect ry="0" x="10.03" y="141.19" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <rect ry="0" x="5.17" y="165.1" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="10.03" y="169.09" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <circle x="-57.12" y="475.3" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="22.4"/>
+        <rect ry="0" x="-2.6" y="81.4" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="34.97" height="167.4" rx="0"/>
+        <ellipse x="10.03" y="236.85" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="9.71" height="9.96"/>
+        <rect ry="0" x="5.17" y="220.9" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <rect ry="0" x="10.03" y="224.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <arc x="12.6" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="45" width="16" height="16" angle="45"/>
+        <rect ry="0" x="-2.6" y="248.81" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="34.97" height="167.4" rx="0"/>
+        <ellipse x="10.03" y="404.25" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="9.71" height="9.96"/>
+        <rect ry="0" x="5.17" y="388.3" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="15.54" height="13.95" rx="0"/>
+        <circle x="-52" y="480.3" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="12"/>
+        <rect ry="0" x="10.03" y="392.29" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="5.83" height="5.98" rx="0"/>
+        <text x="36.25" y="102.32" font="Liberation Sans,6,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="Up1"/>
+        <line end1="none" end2="none" y1="248.81" antialias="false" y2="248.81" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-20.08" length1="1.5" x2="-47.28" length2="1.5"/>
+        <circle x="-40.12" y="28" antialias="false" style="line-style:normal;line-weight:normal;filling:red;color:black" diameter="24.4"/>
+        <circle x="-45.99" y="348.02" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <line end1="none" end2="none" y1="51.29" antialias="false" y2="48.82" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-32" length1="6" x2="-27.92" length2="6"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="71" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-42" length1="3" x2="-34" length2="3"/>
+        <line end1="none" end2="none" y1="48.82" antialias="false" y2="51.29" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-27.92" length1="6" x2="-23.84" length2="6"/>
+        <line end1="none" end2="none" y1="71" antialias="false" y2="71" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="60" length1="3" x2="42" length2="3"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="71" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="42" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="28" antialias="false" y2="31.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-26.36" length1="6" x2="-26.36" length2="6"/>
+        <arc x="-29.56" y="29.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="3.2" height="3.2" angle="180"/>
+        <line end1="none" end2="none" y1="31.42" antialias="false" y2="28.03" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.56" length1="6" x2="-29.56" length2="6"/>
+        <line end1="none" end2="none" y1="42.64" antialias="false" y2="41.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-26.72" length1="6" x2="-25" length2="6"/>
+        <line end1="none" end2="none" y1="45.42" antialias="false" y2="42.64" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-26.72" length1="6" x2="-26.72" length2="6"/>
+        <arc x="-29.12" y="44.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="2.4" height="2.4" angle="180"/>
+        <line end1="none" end2="none" y1="42.64" antialias="false" y2="45.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.12" length1="6" x2="-29.12" length2="6"/>
+        <line end1="none" end2="none" y1="41.22" antialias="false" y2="42.64" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-30.82" length1="6" x2="-29.12" length2="6"/>
+        <line end1="none" end2="none" y1="41.22" antialias="false" y2="41.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-32.52" length1="6" x2="-30.82" length2="6"/>
+        <arc x="-33.52" y="39.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="90" width="2" height="2" angle="180"/>
+        <line end1="none" end2="none" y1="39.22" antialias="false" y2="39.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-23.32" length1="6" x2="-32.52" length2="6"/>
+        <arc x="-24.32" y="39.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="270" width="2" height="2" angle="180"/>
+        <line end1="none" end2="none" y1="41.22" antialias="false" y2="41.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-25" length1="6" x2="-23.32" length2="6"/>
+        <circle x="-25.16" y="33.06" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-35.06" y="43" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-35.06" y="33.06" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="15.88" y="28" antialias="false" style="line-style:normal;line-weight:normal;filling:red;color:black" diameter="24.4"/>
+        <circle x="-25.16" y="43" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="11.28" y="23.42" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
+        <line end1="none" end2="none" y1="51.39" antialias="false" y2="48.82" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="24" length1="6" x2="28.08" length2="6"/>
+        <line end1="none" end2="none" y1="48.82" antialias="false" y2="51.39" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="28.08" length1="6" x2="32.16" length2="6"/>
+        <line end1="none" end2="none" y1="28.26" antialias="false" y2="31.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.64" length1="6" x2="29.64" length2="6"/>
+        <arc x="26.44" y="29.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="3.2" height="3.2" angle="180"/>
+        <line end1="none" end2="none" y1="31.42" antialias="false" y2="28.29" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="26.44" length1="6" x2="26.44" length2="6"/>
+        <line end1="none" end2="none" y1="42.64" antialias="false" y2="41.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.28" length1="6" x2="31" length2="6"/>
+        <line end1="none" end2="none" y1="45.42" antialias="false" y2="42.64" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.28" length1="6" x2="29.28" length2="6"/>
+        <arc x="26.88" y="44.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="2.4" height="2.4" angle="180"/>
+        <line end1="none" end2="none" y1="42.64" antialias="false" y2="45.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="26.88" length1="6" x2="26.88" length2="6"/>
+        <line end1="none" end2="none" y1="41.22" antialias="false" y2="42.64" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="25.18" length1="6" x2="26.88" length2="6"/>
+        <line end1="none" end2="none" y1="41.22" antialias="false" y2="41.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="23.48" length1="6" x2="25.18" length2="6"/>
+        <arc x="22.48" y="39.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="90" width="2" height="2" angle="180"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-34" y="474.3" z="121" rotation="0" font="Liberation Sans,8,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{b5ec55a8-7f78-1b91-4ada-ed2333c17cda}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
+            <text>EPP2339-0003</text>
+            <info_name>designation</info_name>
+        </dynamic_text>
+        <line end1="none" end2="none" y1="39.22" antialias="false" y2="39.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="32.68" length1="6" x2="23.48" length2="6"/>
+        <arc x="31.68" y="39.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="270" width="2" height="2" angle="180"/>
+        <line end1="none" end2="none" y1="41.22" antialias="false" y2="41.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="31" length1="6" x2="32.68" length2="6"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="394.5" z="133" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <circle x="30.84" y="33.06" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="20.94" y="43" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="20.94" y="33.06" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="30.84" y="43" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <line end1="none" end2="none" y1="271" antialias="false" y2="326.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="60.08" length2="6"/>
+        <line end1="none" end2="none" y1="271" antialias="false" y2="271" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="59.42" length1="6" x2="60.08" length2="6"/>
+        <arc x="-43.22" y="-13.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="16" height="16" angle="45"/>
+        <line end1="none" end2="none" y1="-0.12" antialias="false" y2="-3.44" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.56" length1="6" x2="-26.26" length2="6"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-49" y="-36" z="143" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
+            <text></text>
+            <info_name>label</info_name>
+        </dynamic_text>
+        <arc x="27.4" y="492.52" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="16" height="16" angle="45"/>
+        <circle x="4" y="17.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-5" y="53.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-14" y="17.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <dynamic_text frame="false" Halignment="AlignRight" x="-50.49" y="117.23" z="147" rotation="270" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{01f2e6c3-3612-4601-89fd-8a5cd8c0eedf}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>DIO</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignRight" x="-50.49" y="286.63" z="147" rotation="270" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{01f2e6c3-3612-4601-89fd-8a5cd8c0eedf}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>DIO</text>
+        </dynamic_text>
+        <line end1="none" end2="none" y1="267.42" antialias="false" y2="267.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="59.42" length2="6"/>
+        <arc x="-28.6" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="16" height="16" angle="45"/>
+        <line end1="none" end2="none" y1="432.3" antialias="false" y2="432.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-60" length1="3" x2="-42" length2="3"/>
+        <line end1="none" end2="none" y1="432.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-42" length1="3" x2="-34" length2="3"/>
+        <line end1="none" end2="none" y1="424.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="432.3" antialias="false" y2="432.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="60" length1="3" x2="42" length2="3"/>
+        <line end1="none" end2="none" y1="432.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="42" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="495.56" antialias="false" y2="499.56" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="29.06" length1="6" x2="25.06" length2="6"/>
+        <line end1="none" end2="none" y1="492.56" antialias="false" y2="492.53" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="57.88" length1="6" x2="36.02" length2="6"/>
+        <line end1="none" end2="none" y1="2.22" antialias="false" y2="2.22" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-58.28" length1="6" x2="-35.22" length2="6"/>
+        <circle x="40" y="2" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="12"/>
+        <arc x="34" y="-2" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="180" width="24" height="24" angle="90"/>
+        <line end1="none" end2="none" y1="22" antialias="false" y2="22" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="46" length1="3" x2="60" length2="3"/>
+        <line end1="none" end2="none" y1="9" antialias="false" y2="2.28" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="34" length1="3" x2="34" length2="3"/>
+        <text x="-25" y="497.3" font="Liberation Sans,7,-1,5,75,0,0,0,0,0,Bold" rotation="0" color="#000000" text="BECKHOFF"/>
+        <text x="-52" y="462.3" font="Liberation Sans,14,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
+        <text x="-26" y="13" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
+        <terminal type="Generic" x="37.13" y="332.51" name="" uuid="{3ae4968f-2bb1-4c72-a05d-84c6416e005d}" orientation="e"/>
+        <terminal type="Generic" x="37.13" y="165.1" name="" uuid="{45f8c2a3-8976-4231-8dad-1b5957b95d38}" orientation="e"/>
+        <terminal type="Generic" x="-40" y="40" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
+        <terminal type="Generic" x="40" y="40" name="X51" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+    </description>
+</definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_126x30_4xm12a-5.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_126x30_4xm12a-5.elmt
@@ -1,5 +1,5 @@
 <definition type="element" link_type="simple" hotspot_x="35" hotspot_y="6" width="70" height="260" version="0.100.1">
-    <uuid uuid="{b1d9d6c9-1f7a-4fd4-9ebf-4815f1236872}"/>
+    <uuid uuid="{0a6b3aaf-793d-4ca6-b178-fe9594141f92}"/>
     <names>
         <name lang="de">EPPxxxx |1:1| 126,5x30mm | 4x M12-Buchse, 5-polig, A-kodiert</name>
         <name lang="en">EPPxxxx |1:1| 126.5x30mm | 4x M12-socket, 5-pol, a-coded</name>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_126x30_4xm12a-5.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_126x30_4xm12a-5.elmt
@@ -1,0 +1,203 @@
+<definition type="element" link_type="simple" hotspot_x="35" hotspot_y="6" width="70" height="260" version="0.100.1">
+    <uuid uuid="{57ebe3f1-0006-4388-a52e-c1b36ec1191b}"/>
+    <names>
+        <name lang="de">EPPxxxx |1:1| 126,5x30mm | 4x M12-Buchse, 5-polig, A-kodiert</name>
+        <name lang="en">EPPxxxx |1:1| 126.5x30mm | 4x M12-socket, 5-pol, a-coded</name>
+    </names>
+    <elementInformations>
+        <elementInformation name="designation" show="1">EPP1008-0002</elementInformation>
+        <elementInformation name="manufacturer" show="1">Beckhoff</elementInformation>
+    </elementInformations>
+    <informations>Author: Moritz Scholjegerdes</informations>
+    <description>
+        <circle x="-14.23" y="97.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <text x="20" y="76" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="1"/>
+        <circle x="-14.23" y="137.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <text x="1" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="OUT"/>
+        <rect ry="0" x="-27" y="65" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <circle x="-14.23" y="177.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-24.77" y="97.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <text x="20" y="116" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="6"/>
+        <rect ry="0" x="-27" y="85" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <circle x="-24.77" y="137.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-24.77" y="177.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <text x="20" y="156" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="5"/>
+        <circle x="-14.23" y="57.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <arc x="-21.61" y="245.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="54.5" width="8" height="8" angle="24.8125"/>
+        <circle x="-24.77" y="57.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <text x="20" y="196" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="7"/>
+        <circle x="17.44" y="-1.49" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="11.2"/>
+        <circle x="12.4" y="133.7" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <rect ry="0" x="-27" y="105" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <circle x="12.4" y="173.7" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="12.4" y="93.7" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <rect ry="0" x="-27" y="145" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <circle x="12.4" y="53.7" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="10.9" y="138.9" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <line end1="none" end2="none" y1="247.06" antialias="false" y2="248.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-14.78" length1="3" x2="-13.13" length2="3"/>
+        <circle x="10.9" y="98.9" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="10.9" y="178.9" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <arc x="-14.3" y="241.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="8" height="8" angle="-45"/>
+        <circle x="10.9" y="58.9" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="9.2" y="184.1" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <rect ry="0" x="-27" y="165" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <circle x="9.2" y="104.1" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <rect ry="0" x="-27" y="185" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <circle x="9.2" y="144.1" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="9.2" y="64.1" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="5.6" y="177.6" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <arc x="-29" y="236" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="0" width="12" height="12" angle="90"/>
+        <circle x="5.6" y="97.6" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="5.6" y="137.6" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <rect ry="0" x="-27" y="199" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <circle x="16.1" y="180.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="16.1" y="100.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <line end1="none" end2="none" y1="236" antialias="false" y2="236" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-23" length1="1.5" x2="-30" length2="1.5"/>
+        <circle x="16.1" y="140.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="3" y="91" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="18"/>
+        <circle x="-22.36" y="11.71" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.8"/>
+        <circle x="3" y="131" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="18"/>
+        <circle x="3" y="171" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="18"/>
+        <circle x="-0.5" y="127.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="25"/>
+        <line end1="none" end2="none" y1="243" antialias="false" y2="245.86" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="-17" length2="1.5"/>
+        <circle x="-0.5" y="87.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="25"/>
+        <arc x="13.61" y="-6.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="234.5" width="8" height="8" angle="24.8125"/>
+        <circle x="5.6" y="57.6" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-0.5" y="167.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="25"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="31.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-30" length1="1.5" x2="-21" length2="1.5"/>
+        <polygon y1="143.65" antialias="false" y2="141.79" y3="143.1" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="3.89" y4="145.11" x2="6.98" x3="7.76" x4="4.72"/>
+        <polygon y1="103.65" antialias="false" y2="101.79" y3="103.1" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="3.89" y4="105.11" x2="6.98" x3="7.76" x4="4.72"/>
+        <polygon y1="183.65" antialias="false" y2="181.79" y3="183.1" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="3.89" y4="185.11" x2="6.98" x3="7.76" x4="4.72"/>
+        <line end1="none" end2="none" y1="-0.06" antialias="false" y2="-1.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="14.78" length1="3" x2="13.13" length2="3"/>
+        <circle x="-28.56" y="237.51" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="11.2"/>
+        <circle x="16.1" y="60.5" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <text x="0" y="116" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="2"/>
+        <arc x="6.3" y="-2.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="-45"/>
+        <text x="0" y="156" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="4"/>
+        <text x="0" y="196" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="6"/>
+        <circle x="-26" y="240" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="6"/>
+        <circle x="3" y="51" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="18"/>
+        <circle x="-0.5" y="47.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="25"/>
+        <polygon y1="63.65" antialias="false" y2="61.79" y3="63.1" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="3.89" y4="65.11" x2="6.98" x3="7.76" x4="4.72"/>
+        <text x="0" y="76" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="0"/>
+        <circle x="-20.06" y="14.01" antialias="false" style="line-style:normal;line-weight:normal;filling:red;color:black" diameter="12.2"/>
+        <line end1="none" end2="none" y1="25.36" antialias="false" y2="24.41" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-15.99" length1="3" x2="-13.96" length2="3"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="35.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-21" length1="1.5" x2="-17" length2="1.5"/>
+        <rect ry="0" x="-27" y="45" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <circle x="16.04" y="203.41" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <line end1="none" end2="none" y1="24.41" antialias="false" y2="25.36" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-13.96" length1="3" x2="-11.92" length2="3"/>
+        <line end1="none" end2="none" y1="35.5" antialias="false" y2="35.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="31.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="30" length1="1.5" x2="21" length2="1.5"/>
+        <circle x="7.04" y="203.41" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="35.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="21" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="14.56" antialias="false" y2="15.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-13.18" length1="3" x2="-13.18" length2="3"/>
+        <arc x="-14.78" y="14.91" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="1.6" height="1.6" angle="180"/>
+        <line end1="none" end2="none" y1="15.71" antialias="false" y2="14.57" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-14.78" length1="3" x2="-14.78" length2="3"/>
+        <line end1="none" end2="none" y1="21.32" antialias="false" y2="20.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-13.36" length1="3" x2="-12.51" length2="3"/>
+        <line end1="none" end2="none" y1="22.71" antialias="false" y2="21.32" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-13.36" length1="3" x2="-13.36" length2="3"/>
+        <arc x="-14.56" y="22.11" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="1.2" height="1.2" angle="180"/>
+        <line end1="none" end2="none" y1="21.32" antialias="false" y2="22.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-14.56" length1="3" x2="-14.56" length2="3"/>
+        <line end1="none" end2="none" y1="20.61" antialias="false" y2="21.32" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-15.41" length1="3" x2="-14.56" length2="3"/>
+        <line end1="none" end2="none" y1="20.61" antialias="false" y2="20.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-16.26" length1="3" x2="-15.41" length2="3"/>
+        <arc x="-16.76" y="19.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="90" width="1" height="1" angle="180"/>
+        <line end1="none" end2="none" y1="19.61" antialias="false" y2="19.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-11.66" length1="3" x2="-16.26" length2="3"/>
+        <arc x="-12.16" y="19.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="270" width="1" height="1" angle="180"/>
+        <line end1="none" end2="none" y1="20.61" antialias="false" y2="20.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-12.51" length1="3" x2="-11.66" length2="3"/>
+        <circle x="-12.58" y="16.53" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-17.53" y="21.48" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-17.53" y="16.53" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="7.94" y="14.01" antialias="false" style="line-style:normal;line-weight:normal;filling:red;color:black" diameter="12.2"/>
+        <circle x="-12.58" y="21.48" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="5.64" y="11.71" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.8"/>
+        <line end1="none" end2="none" y1="25.36" antialias="false" y2="24.41" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="12.01" length1="3" x2="14.04" length2="3"/>
+        <line end1="none" end2="none" y1="24.41" antialias="false" y2="25.36" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="14.04" length1="3" x2="16.08" length2="3"/>
+        <line end1="none" end2="none" y1="14.56" antialias="false" y2="15.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="14.82" length1="3" x2="14.82" length2="3"/>
+        <arc x="13.22" y="14.91" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="1.6" height="1.6" angle="180"/>
+        <line end1="none" end2="none" y1="15.71" antialias="false" y2="14.57" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="13.22" length1="3" x2="13.22" length2="3"/>
+        <line end1="none" end2="none" y1="21.32" antialias="false" y2="20.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="14.64" length1="3" x2="15.49" length2="3"/>
+        <line end1="none" end2="none" y1="22.71" antialias="false" y2="21.32" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="14.64" length1="3" x2="14.64" length2="3"/>
+        <arc x="13.44" y="22.11" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="1.2" height="1.2" angle="180"/>
+        <line end1="none" end2="none" y1="21.32" antialias="false" y2="22.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="13.44" length1="3" x2="13.44" length2="3"/>
+        <line end1="none" end2="none" y1="20.61" antialias="false" y2="21.32" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="12.59" length1="3" x2="13.44" length2="3"/>
+        <line end1="none" end2="none" y1="20.61" antialias="false" y2="20.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="11.74" length1="3" x2="12.59" length2="3"/>
+        <arc x="11.24" y="19.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="90" width="1" height="1" angle="180"/>
+        <line end1="none" end2="none" y1="19.61" antialias="false" y2="19.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="16.34" length1="3" x2="11.74" length2="3"/>
+        <arc x="15.84" y="19.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="270" width="1" height="1" angle="180"/>
+        <line end1="none" end2="none" y1="20.61" antialias="false" y2="20.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="15.49" length1="3" x2="16.34" length2="3"/>
+        <circle x="15.42" y="16.53" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="10.47" y="21.48" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="10.47" y="16.53" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="15.42" y="21.48" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <line end1="none" end2="none" y1="30.71" antialias="false" y2="3.11" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.96" length1="3" x2="-29.96" length2="3"/>
+        <line end1="none" end2="none" y1="133.71" antialias="false" y2="32.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.96" length1="3" x2="-29.96" length2="3"/>
+        <line end1="none" end2="none" y1="135.51" antialias="false" y2="163.11" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="30.04" length2="3"/>
+        <line end1="none" end2="none" y1="32.51" antialias="false" y2="133.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="30.04" length2="3"/>
+        <line end1="none" end2="none" y1="135.51" antialias="false" y2="135.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.71" length1="3" x2="30.04" length2="3"/>
+        <arc x="-21.61" y="-6.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="8" height="8" angle="45"/>
+        <line end1="none" end2="none" y1="-0.06" antialias="false" y2="-1.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-14.78" length1="3" x2="-13.13" length2="3"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-17" y="233" z="119" rotation="0" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{4716c2f4-3f3a-441c-93c8-f90e91168538}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
+            <text>EPP1008-0002</text>
+            <info_name>designation</info_name>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="41.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="81.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="101.4" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21.04" y="141.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="161.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="195.4" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="181.4" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21.04" y="61.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="121.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <arc x="13.7" y="246.11" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
+        <circle x="2" y="9.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-2.5" y="26.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-7" y="9.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <line end1="none" end2="none" y1="133.71" antialias="false" y2="133.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="29.71" length2="3"/>
+        <arc x="-14.3" y="-2.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
+        <rect ry="7" x="-30" y="-3" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="60" height="253" rx="7"/>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="216" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-30" length1="1.5" x2="-21" length2="1.5"/>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-21" length1="1.5" x2="-17" length2="1.5"/>
+        <line end1="none" end2="none" y1="212" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="216" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="30" length1="1.5" x2="21" length2="1.5"/>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="21" length1="1.5" x2="17" length2="1.5"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-29" y="-30" z="141" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
+            <text></text>
+            <info_name>label</info_name>
+        </dynamic_text>
+        <line end1="none" end2="none" y1="247.63" antialias="false" y2="249.63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="14.53" length1="3" x2="12.53" length2="3"/>
+        <line end1="none" end2="none" y1="246.13" antialias="false" y2="246.11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="28.94" length1="3" x2="18.51" length2="3"/>
+        <line end1="none" end2="none" y1="1.11" antialias="false" y2="1.11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.14" length1="3" x2="-17.61" length2="3"/>
+        <circle x="20" y="1" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="6"/>
+        <rect ry="0" x="-27" y="125" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <arc x="17" y="-1" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="180" width="12" height="12" angle="90"/>
+        <line end1="none" end2="none" y1="11" antialias="false" y2="11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="23" length1="1.5" x2="30" length2="1.5"/>
+        <line end1="none" end2="none" y1="4" antialias="false" y2="1.14" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="17" length1="1.5" x2="17" length2="1.5"/>
+        <text x="-13" y="247" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="BECKHOFF"/>
+        <text x="-26" y="233" font="Liberation Sans,7,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
+        <text x="-13" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
+        <terminal type="Generic" x="20" y="180" name="X04" uuid="{60b9341a-9779-45b8-9493-0a5115b22397}" orientation="e"/>
+        <terminal type="Generic" x="20" y="100" name="X02" uuid="{3198c2d2-a483-4b11-925b-131ac9631aff}" orientation="e"/>
+        <terminal type="Generic" x="-20" y="20" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
+        <terminal type="Generic" x="20" y="60" name="X01" uuid="{b5cab7e7-035d-4051-bdf0-bd7d00a133a5}" orientation="e"/>
+        <terminal type="Generic" x="20" y="140" name="X03" uuid="{f3cfd4aa-2a58-4a57-ba85-b85621402d63}" orientation="e"/>
+        <terminal type="Generic" x="20" y="20" name="X51" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+    </description>
+</definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_126x30_4xm12a-5.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_126x30_4xm12a-5.elmt
@@ -1,5 +1,5 @@
 <definition type="element" link_type="simple" hotspot_x="35" hotspot_y="6" width="70" height="260" version="0.100.1">
-    <uuid uuid="{57ebe3f1-0006-4388-a52e-c1b36ec1191b}"/>
+    <uuid uuid="{b1d9d6c9-1f7a-4fd4-9ebf-4815f1236872}"/>
     <names>
         <name lang="de">EPPxxxx |1:1| 126,5x30mm | 4x M12-Buchse, 5-polig, A-kodiert</name>
         <name lang="en">EPPxxxx |1:1| 126.5x30mm | 4x M12-socket, 5-pol, a-coded</name>
@@ -10,6 +10,8 @@
     </elementInformations>
     <informations>Author: Moritz Scholjegerdes</informations>
     <description>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="35.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-21" length1="1.5" x2="-17" length2="1.5"/>
+        <rect ry="7" x="-30" y="-3" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="60" height="253" rx="7"/>
         <circle x="-14.23" y="97.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
         <text x="20" y="76" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="1"/>
         <circle x="-14.23" y="137.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
@@ -82,7 +84,6 @@
         <text x="0" y="76" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="0"/>
         <circle x="-20.06" y="14.01" antialias="false" style="line-style:normal;line-weight:normal;filling:red;color:black" diameter="12.2"/>
         <line end1="none" end2="none" y1="25.36" antialias="false" y2="24.41" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-15.99" length1="3" x2="-13.96" length2="3"/>
-        <line end1="none" end2="none" y1="31.5" antialias="false" y2="35.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-21" length1="1.5" x2="-17" length2="1.5"/>
         <rect ry="0" x="-27" y="45" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
         <circle x="16.04" y="203.41" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
         <line end1="none" end2="none" y1="24.41" antialias="false" y2="25.36" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-13.96" length1="3" x2="-11.92" length2="3"/>
@@ -128,60 +129,55 @@
         <circle x="10.47" y="21.48" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
         <circle x="10.47" y="16.53" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
         <circle x="15.42" y="21.48" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
-        <line end1="none" end2="none" y1="30.71" antialias="false" y2="3.11" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.96" length1="3" x2="-29.96" length2="3"/>
-        <line end1="none" end2="none" y1="133.71" antialias="false" y2="32.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.96" length1="3" x2="-29.96" length2="3"/>
-        <line end1="none" end2="none" y1="135.51" antialias="false" y2="163.11" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="30.04" length2="3"/>
-        <line end1="none" end2="none" y1="32.51" antialias="false" y2="133.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="30.04" length2="3"/>
-        <line end1="none" end2="none" y1="135.51" antialias="false" y2="135.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.71" length1="3" x2="30.04" length2="3"/>
-        <arc x="-21.61" y="-6.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="8" height="8" angle="45"/>
-        <line end1="none" end2="none" y1="-0.06" antialias="false" y2="-1.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-14.78" length1="3" x2="-13.13" length2="3"/>
-        <dynamic_text frame="false" Halignment="AlignLeft" x="-17" y="233" z="119" rotation="0" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{4716c2f4-3f3a-441c-93c8-f90e91168538}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-17" y="233" z="120" rotation="0" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{4716c2f4-3f3a-441c-93c8-f90e91168538}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
             <text>EPP1008-0002</text>
             <info_name>designation</info_name>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="41.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text></text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="81.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text></text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="101.4" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text></text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21.04" y="141.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text></text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="161.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text></text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="195.4" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text></text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="181.4" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <line end1="none" end2="none" y1="135.51" antialias="false" y2="135.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.71" length1="3" x2="30.04" length2="3"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="121.5" z="122" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text></text>
         </dynamic_text>
         <dynamic_text frame="false" Halignment="AlignHCenter" x="-21.04" y="61.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text></text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="121.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="181.4" z="124" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text></text>
         </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="195.4" z="125" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="161.5" z="126" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21.04" y="141.5" z="127" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="101.4" z="128" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="81.5" z="129" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="41.5" z="130" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <arc x="-21.61" y="-6.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="8" height="8" angle="45"/>
+        <line end1="none" end2="none" y1="-0.06" antialias="false" y2="-1.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-14.78" length1="3" x2="-13.13" length2="3"/>
         <arc x="13.7" y="246.11" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
         <circle x="2" y="9.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
         <circle x="-2.5" y="26.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
         <circle x="-7" y="9.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
         <line end1="none" end2="none" y1="133.71" antialias="false" y2="133.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="29.71" length2="3"/>
         <arc x="-14.3" y="-2.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
-        <rect ry="7" x="-30" y="-3" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="60" height="253" rx="7"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-29" y="-30" z="139" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
+            <text></text>
+            <info_name>label</info_name>
+        </dynamic_text>
         <line end1="none" end2="none" y1="216" antialias="false" y2="216" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-30" length1="1.5" x2="-21" length2="1.5"/>
         <line end1="none" end2="none" y1="216" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-21" length1="1.5" x2="-17" length2="1.5"/>
         <line end1="none" end2="none" y1="212" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="17" length2="1.5"/>
         <line end1="none" end2="none" y1="216" antialias="false" y2="216" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="30" length1="1.5" x2="21" length2="1.5"/>
         <line end1="none" end2="none" y1="216" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="21" length1="1.5" x2="17" length2="1.5"/>
-        <dynamic_text frame="false" Halignment="AlignLeft" x="-29" y="-30" z="141" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
-            <text></text>
-            <info_name>label</info_name>
-        </dynamic_text>
         <line end1="none" end2="none" y1="247.63" antialias="false" y2="249.63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="14.53" length1="3" x2="12.53" length2="3"/>
         <line end1="none" end2="none" y1="246.13" antialias="false" y2="246.11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="28.94" length1="3" x2="18.51" length2="3"/>
         <line end1="none" end2="none" y1="1.11" antialias="false" y2="1.11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.14" length1="3" x2="-17.61" length2="3"/>
@@ -193,11 +189,11 @@
         <text x="-13" y="247" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="BECKHOFF"/>
         <text x="-26" y="233" font="Liberation Sans,7,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
         <text x="-13" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
-        <terminal type="Generic" x="20" y="180" name="X04" uuid="{60b9341a-9779-45b8-9493-0a5115b22397}" orientation="e"/>
         <terminal type="Generic" x="20" y="100" name="X02" uuid="{3198c2d2-a483-4b11-925b-131ac9631aff}" orientation="e"/>
         <terminal type="Generic" x="-20" y="20" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
         <terminal type="Generic" x="20" y="60" name="X01" uuid="{b5cab7e7-035d-4051-bdf0-bd7d00a133a5}" orientation="e"/>
-        <terminal type="Generic" x="20" y="140" name="X03" uuid="{f3cfd4aa-2a58-4a57-ba85-b85621402d63}" orientation="e"/>
+        <terminal type="Generic" x="20" y="180" name="X04" uuid="{60b9341a-9779-45b8-9493-0a5115b22397}" orientation="e"/>
         <terminal type="Generic" x="20" y="20" name="X51" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+        <terminal type="Generic" x="20" y="140" name="X03" uuid="{f3cfd4aa-2a58-4a57-ba85-b85621402d63}" orientation="e"/>
     </description>
 </definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_126x30_4xm12a-5_x2.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_126x30_4xm12a-5_x2.elmt
@@ -1,0 +1,209 @@
+<definition type="element" link_type="simple" hotspot_x="65" hotspot_y="8" width="130" height="510" version="0.100.1">
+    <uuid uuid="{00c0ecf1-60be-49b6-8eb5-ee860ee31a31}"/>
+    <names>
+        <name lang="de">EPPxxxx |2:1| 126,5x30mm | 4x M12-Buchse, 5-polig, A-kodiert</name>
+        <name lang="en">EPPxxxx |2:1| 126.5x30mm | 4x M12-socket, 5-pol, a-coded</name>
+    </names>
+    <elementInformations>
+        <elementInformation name="designation" show="1">EPP1008-0002</elementInformation>
+        <elementInformation name="manufacturer" show="1">Beckhoff</elementInformation>
+    </elementInformations>
+    <informations>Author: Moritz Scholjegerdes</informations>
+    <description>
+        <rect ry="0" x="-54" y="130" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <circle x="-28" y="355" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-28" y="115" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <line end1="none" end2="none" y1="290.35" antialias="false" y2="286.36" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="9.8" length1="1.5" x2="16.87" length2="1.5"/>
+        <circle x="-28" y="275" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <text x="2" y="13" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="OUT"/>
+        <circle x="-28" y="195" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <line end1="none" end2="none" y1="130.35" antialias="false" y2="126.36" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="9.8" length1="1.5" x2="16.87" length2="1.5"/>
+        <circle x="-50" y="275" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <line end1="none" end2="none" y1="210.35" antialias="false" y2="206.36" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="9.8" length1="1.5" x2="16.87" length2="1.5"/>
+        <arc x="-43.22" y="492.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="51.4375" width="16" height="16" angle="28.5"/>
+        <circle x="-50" y="355" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <rect ry="0" x="-54" y="170" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <circle x="-50" y="195" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-50" y="115" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <line end1="none" end2="none" y1="370.35" antialias="false" y2="366.36" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="9.8" length1="1.5" x2="16.87" length2="1.5"/>
+        <text x="41" y="228.05" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="3"/>
+        <circle x="34.88" y="-3" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="22.4"/>
+        <text x="41" y="148.05" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="1"/>
+        <rect ry="0" x="-54" y="210" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <rect ry="0" x="-54" y="290" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <circle x="24.9" y="187.35" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <text x="41" y="388.05" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="7"/>
+        <circle x="21.8" y="197.85" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <line end1="none" end2="none" y1="494.42" antialias="false" y2="497.74" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.56" length1="6" x2="-26.26" length2="6"/>
+        <text x="41" y="308.05" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="5"/>
+        <circle x="18.4" y="208.25" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="24.9" y="347.35" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <arc x="-28.6" y="484.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="225" width="16" height="16" angle="45"/>
+        <circle x="21.8" y="357.85" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <rect ry="0" x="-54" y="330" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <circle x="11.2" y="195.25" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="32.3" y="201.05" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <rect ry="0" x="-54" y="370" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <circle x="18.4" y="368.25" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="6" y="182.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="36"/>
+        <circle x="11.2" y="355.25" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <arc x="-58" y="472.3" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="0" width="24" height="24" angle="90"/>
+        <rect ry="0" x="-54" y="396" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <circle x="-1" y="175.05" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="50"/>
+        <circle x="32.3" y="361.05" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <line end1="none" end2="none" y1="472.3" antialias="false" y2="472.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-46" length1="3" x2="-60" length2="3"/>
+        <circle x="6" y="342.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="36"/>
+        <text x="1" y="228.05" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="2"/>
+        <circle x="-1" y="335.05" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="50"/>
+        <circle x="-44.72" y="23.42" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
+        <line end1="none" end2="none" y1="207.05" antialias="false" y2="203.06" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="7.5" length1="1.5" x2="14.57" length2="1.5"/>
+        <line end1="none" end2="none" y1="485.04" antialias="false" y2="492.02" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="-34" length2="3"/>
+        <arc x="13.7" y="202.75" antialias="true" style="line-style:normal;line-weight:thin;filling:none;color:black" start="305" width="4" height="4" angle="180"/>
+        <text x="1" y="388.05" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="6"/>
+        <circle x="24.9" y="107.35" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <arc x="27.22" y="-13.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="231.25" width="16" height="16" angle="28.6875"/>
+        <line end1="none" end2="none" y1="367.05" antialias="false" y2="363.06" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="7.5" length1="1.5" x2="14.57" length2="1.5"/>
+        <circle x="21.8" y="117.85" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-60" length1="3" x2="-42" length2="3"/>
+        <arc x="13.7" y="362.75" antialias="true" style="line-style:normal;line-weight:thin;filling:none;color:black" start="305" width="4" height="4" angle="180"/>
+        <line end1="none" end2="none" y1="-0.12" antialias="false" y2="-3.44" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="29.56" length1="6" x2="26.26" length2="6"/>
+        <circle x="24.9" y="267.35" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="18.4" y="128.25" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="21.8" y="277.85" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-57.12" y="475.3" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="22.4"/>
+        <circle x="18.4" y="288.25" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="11.2" y="275.25" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <arc x="12.6" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="45" width="16" height="16" angle="45"/>
+        <circle x="11.2" y="115.25" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="32.3" y="281.05" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-52" y="480.3" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="12"/>
+        <circle x="32.3" y="121.05" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="6" y="262.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="36"/>
+        <circle x="6" y="102.05" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="36"/>
+        <circle x="-1" y="255.05" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="50"/>
+        <circle x="-40.12" y="28" antialias="false" style="line-style:normal;line-weight:normal;filling:red;color:black" diameter="24.4"/>
+        <text x="1" y="308.05" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="4"/>
+        <circle x="-1" y="95.05" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="50"/>
+        <line end1="none" end2="none" y1="287.05" antialias="false" y2="283.06" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="7.5" length1="1.5" x2="14.57" length2="1.5"/>
+        <arc x="13.7" y="282.75" antialias="true" style="line-style:normal;line-weight:thin;filling:none;color:black" start="305" width="4" height="4" angle="180"/>
+        <text x="1" y="148.05" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="0"/>
+        <line end1="none" end2="none" y1="127.05" antialias="false" y2="123.06" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="7.5" length1="1.5" x2="14.57" length2="1.5"/>
+        <arc x="13.7" y="122.75" antialias="true" style="line-style:normal;line-weight:thin;filling:none;color:black" start="305" width="4" height="4" angle="180"/>
+        <line end1="none" end2="none" y1="51.29" antialias="false" y2="48.82" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-32" length1="6" x2="-27.92" length2="6"/>
+        <rect ry="0" x="-54" y="90" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="71" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-42" length1="3" x2="-34" length2="3"/>
+        <circle x="32.08" y="404.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <line end1="none" end2="none" y1="48.82" antialias="false" y2="51.29" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-27.92" length1="6" x2="-23.84" length2="6"/>
+        <line end1="none" end2="none" y1="71" antialias="false" y2="71" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="60" length1="3" x2="42" length2="3"/>
+        <circle x="14.08" y="404.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="71" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="42" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="28" antialias="false" y2="31.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-26.36" length1="6" x2="-26.36" length2="6"/>
+        <arc x="-29.56" y="29.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="3.2" height="3.2" angle="180"/>
+        <line end1="none" end2="none" y1="31.42" antialias="false" y2="28.03" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.56" length1="6" x2="-29.56" length2="6"/>
+        <line end1="none" end2="none" y1="42.64" antialias="false" y2="41.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-26.72" length1="6" x2="-25" length2="6"/>
+        <line end1="none" end2="none" y1="45.42" antialias="false" y2="42.64" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-26.72" length1="6" x2="-26.72" length2="6"/>
+        <arc x="-29.12" y="44.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="2.4" height="2.4" angle="180"/>
+        <line end1="none" end2="none" y1="42.64" antialias="false" y2="45.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.12" length1="6" x2="-29.12" length2="6"/>
+        <line end1="none" end2="none" y1="41.22" antialias="false" y2="42.64" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-30.82" length1="6" x2="-29.12" length2="6"/>
+        <line end1="none" end2="none" y1="41.22" antialias="false" y2="41.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-32.52" length1="6" x2="-30.82" length2="6"/>
+        <arc x="-33.52" y="39.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="90" width="2" height="2" angle="180"/>
+        <line end1="none" end2="none" y1="39.22" antialias="false" y2="39.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-23.32" length1="6" x2="-32.52" length2="6"/>
+        <arc x="-24.32" y="39.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="270" width="2" height="2" angle="180"/>
+        <line end1="none" end2="none" y1="41.22" antialias="false" y2="41.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-25" length1="6" x2="-23.32" length2="6"/>
+        <circle x="-25.16" y="33.06" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-35.06" y="43" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-35.06" y="33.06" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="15.88" y="28" antialias="false" style="line-style:normal;line-weight:normal;filling:red;color:black" diameter="24.4"/>
+        <circle x="-25.16" y="43" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="11.28" y="23.42" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
+        <line end1="none" end2="none" y1="51.39" antialias="false" y2="48.82" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="24" length1="6" x2="28.08" length2="6"/>
+        <line end1="none" end2="none" y1="48.82" antialias="false" y2="51.39" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="28.08" length1="6" x2="32.16" length2="6"/>
+        <line end1="none" end2="none" y1="28.26" antialias="false" y2="31.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.64" length1="6" x2="29.64" length2="6"/>
+        <arc x="26.44" y="29.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="3.2" height="3.2" angle="180"/>
+        <line end1="none" end2="none" y1="31.42" antialias="false" y2="28.29" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="26.44" length1="6" x2="26.44" length2="6"/>
+        <line end1="none" end2="none" y1="42.64" antialias="false" y2="41.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.28" length1="6" x2="31" length2="6"/>
+        <line end1="none" end2="none" y1="45.42" antialias="false" y2="42.64" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.28" length1="6" x2="29.28" length2="6"/>
+        <arc x="26.88" y="44.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="2.4" height="2.4" angle="180"/>
+        <line end1="none" end2="none" y1="42.64" antialias="false" y2="45.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="26.88" length1="6" x2="26.88" length2="6"/>
+        <line end1="none" end2="none" y1="41.22" antialias="false" y2="42.64" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="25.18" length1="6" x2="26.88" length2="6"/>
+        <line end1="none" end2="none" y1="41.22" antialias="false" y2="41.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="23.48" length1="6" x2="25.18" length2="6"/>
+        <arc x="22.48" y="39.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="90" width="2" height="2" angle="180"/>
+        <line end1="none" end2="none" y1="39.22" antialias="false" y2="39.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="32.68" length1="6" x2="23.48" length2="6"/>
+        <arc x="31.68" y="39.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="270" width="2" height="2" angle="180"/>
+        <line end1="none" end2="none" y1="41.22" antialias="false" y2="41.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="31" length1="6" x2="32.68" length2="6"/>
+        <circle x="30.84" y="33.06" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="20.94" y="43" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="20.94" y="33.06" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="30.84" y="43" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-34" y="474.3" z="119" rotation="0" font="Liberation Sans,8,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{b5ec55a8-7f78-1b91-4ada-ed2333c17cda}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
+            <text>EPP1008-0002</text>
+            <info_name>designation</info_name>
+        </dynamic_text>
+        <line end1="none" end2="none" y1="427.42" antialias="false" y2="225" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-59.92" length1="6" x2="-59.92" length2="6"/>
+        <line end1="none" end2="none" y1="271" antialias="false" y2="326.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="60.08" length2="6"/>
+        <line end1="none" end2="none" y1="271" antialias="false" y2="271" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="59.42" length1="6" x2="60.08" length2="6"/>
+        <arc x="-43.22" y="-13.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="16" height="16" angle="45"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="208.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.58" y="128.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.58" y="288.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="368.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="248.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="88.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="328.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="168.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="394.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <line end1="none" end2="none" y1="-0.12" antialias="false" y2="-3.44" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.56" length1="6" x2="-26.26" length2="6"/>
+        <arc x="27.4" y="492.52" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="16" height="16" angle="45"/>
+        <circle x="4" y="17.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-5" y="53.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-14" y="17.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <line end1="none" end2="none" y1="267.42" antialias="false" y2="267.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="59.42" length2="6"/>
+        <arc x="-28.6" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="16" height="16" angle="45"/>
+        <rect ry="14" x="-60" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="120" height="506" rx="14"/>
+        <line end1="none" end2="none" y1="432.3" antialias="false" y2="432.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-60" length1="3" x2="-42" length2="3"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-49" y="-36" z="141" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
+            <text></text>
+            <info_name>label</info_name>
+        </dynamic_text>
+        <line end1="none" end2="none" y1="432.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-42" length1="3" x2="-34" length2="3"/>
+        <line end1="none" end2="none" y1="424.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="432.3" antialias="false" y2="432.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="60" length1="3" x2="42" length2="3"/>
+        <line end1="none" end2="none" y1="432.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="42" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="495.56" antialias="false" y2="499.56" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="29.06" length1="6" x2="25.06" length2="6"/>
+        <line end1="none" end2="none" y1="492.56" antialias="false" y2="492.53" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="57.88" length1="6" x2="36.02" length2="6"/>
+        <line end1="none" end2="none" y1="2.22" antialias="false" y2="2.22" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-58.28" length1="6" x2="-35.22" length2="6"/>
+        <circle x="40" y="2" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="12"/>
+        <rect ry="0" x="-54" y="250" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <arc x="34" y="-2" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="180" width="24" height="24" angle="90"/>
+        <line end1="none" end2="none" y1="22" antialias="false" y2="22" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="46" length1="3" x2="60" length2="3"/>
+        <line end1="none" end2="none" y1="9" antialias="false" y2="2.28" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="34" length1="3" x2="34" length2="3"/>
+        <text x="-25" y="497.3" font="Liberation Sans,7,-1,5,75,0,0,0,0,0,Bold" rotation="0" color="#000000" text="BECKHOFF"/>
+        <text x="-52" y="462.3" font="Liberation Sans,14,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
+        <text x="-26" y="13" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
+        <terminal type="Generic" x="40" y="360" name="X04" uuid="{8301c6d7-608d-43c3-8c4b-dff9f4f67714}" orientation="e"/>
+        <terminal type="Generic" x="40" y="120" name="X01" uuid="{d3bd70c9-25a0-45c6-b53d-d48eb21e382d}" orientation="e"/>
+        <terminal type="Generic" x="40" y="280" name="X03" uuid="{097f479d-8668-4790-b20b-0ef00598f5ad}" orientation="e"/>
+        <terminal type="Generic" x="40" y="200" name="X02" uuid="{65cc4023-6fdf-4e19-a669-98fa2e38d411}" orientation="e"/>
+        <terminal type="Generic" x="-40" y="40" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
+        <terminal type="Generic" x="40" y="40" name="X51" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+    </description>
+</definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_126x30_4xm12a-5_x2.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_126x30_4xm12a-5_x2.elmt
@@ -1,5 +1,5 @@
 <definition type="element" link_type="simple" hotspot_x="65" hotspot_y="8" width="130" height="510" version="0.100.1">
-    <uuid uuid="{00c0ecf1-60be-49b6-8eb5-ee860ee31a31}"/>
+    <uuid uuid="{72d927d7-64e2-49ec-8ae5-6fd9066bc9d3}"/>
     <names>
         <name lang="de">EPPxxxx |2:1| 126,5x30mm | 4x M12-Buchse, 5-polig, A-kodiert</name>
         <name lang="en">EPPxxxx |2:1| 126.5x30mm | 4x M12-socket, 5-pol, a-coded</name>
@@ -10,6 +10,7 @@
     </elementInformations>
     <informations>Author: Moritz Scholjegerdes</informations>
     <description>
+        <rect ry="14" x="-60" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="120" height="506" rx="14"/>
         <rect ry="0" x="-54" y="130" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
         <circle x="-28" y="355" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
         <circle x="-28" y="115" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
@@ -129,61 +130,60 @@
         <line end1="none" end2="none" y1="41.22" antialias="false" y2="42.64" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="25.18" length1="6" x2="26.88" length2="6"/>
         <line end1="none" end2="none" y1="41.22" antialias="false" y2="41.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="23.48" length1="6" x2="25.18" length2="6"/>
         <arc x="22.48" y="39.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="90" width="2" height="2" angle="180"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-34" y="474.3" z="121" rotation="0" font="Liberation Sans,8,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{b5ec55a8-7f78-1b91-4ada-ed2333c17cda}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
+            <text>EPP1008-0002</text>
+            <info_name>designation</info_name>
+        </dynamic_text>
         <line end1="none" end2="none" y1="39.22" antialias="false" y2="39.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="32.68" length1="6" x2="23.48" length2="6"/>
         <arc x="31.68" y="39.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="270" width="2" height="2" angle="180"/>
         <line end1="none" end2="none" y1="41.22" antialias="false" y2="41.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="31" length1="6" x2="32.68" length2="6"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.58" y="288.5" z="125" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.58" y="128.5" z="126" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="208.5" z="127" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="368.5" z="128" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="248.5" z="129" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="88.5" z="130" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="328.5" z="131" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="168.5" z="132" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="394.5" z="133" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
         <circle x="30.84" y="33.06" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
         <circle x="20.94" y="43" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
         <circle x="20.94" y="33.06" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
         <circle x="30.84" y="43" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
-        <dynamic_text frame="false" Halignment="AlignLeft" x="-34" y="474.3" z="119" rotation="0" font="Liberation Sans,8,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{b5ec55a8-7f78-1b91-4ada-ed2333c17cda}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
-            <text>EPP1008-0002</text>
-            <info_name>designation</info_name>
-        </dynamic_text>
         <line end1="none" end2="none" y1="427.42" antialias="false" y2="225" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-59.92" length1="6" x2="-59.92" length2="6"/>
         <line end1="none" end2="none" y1="271" antialias="false" y2="326.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="60.08" length2="6"/>
         <line end1="none" end2="none" y1="271" antialias="false" y2="271" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="59.42" length1="6" x2="60.08" length2="6"/>
         <arc x="-43.22" y="-13.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="16" height="16" angle="45"/>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="208.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text></text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.58" y="128.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text></text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.58" y="288.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text></text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="368.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text></text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="248.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text></text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="88.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text></text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="328.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text></text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="168.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text></text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="394.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text></text>
-        </dynamic_text>
         <line end1="none" end2="none" y1="-0.12" antialias="false" y2="-3.44" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.56" length1="6" x2="-26.26" length2="6"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-49" y="-36" z="143" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
+            <text></text>
+            <info_name>label</info_name>
+        </dynamic_text>
         <arc x="27.4" y="492.52" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="16" height="16" angle="45"/>
         <circle x="4" y="17.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
         <circle x="-5" y="53.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
         <circle x="-14" y="17.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
         <line end1="none" end2="none" y1="267.42" antialias="false" y2="267.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="59.42" length2="6"/>
         <arc x="-28.6" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="16" height="16" angle="45"/>
-        <rect ry="14" x="-60" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="120" height="506" rx="14"/>
         <line end1="none" end2="none" y1="432.3" antialias="false" y2="432.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-60" length1="3" x2="-42" length2="3"/>
-        <dynamic_text frame="false" Halignment="AlignLeft" x="-49" y="-36" z="141" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
-            <text></text>
-            <info_name>label</info_name>
-        </dynamic_text>
         <line end1="none" end2="none" y1="432.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-42" length1="3" x2="-34" length2="3"/>
         <line end1="none" end2="none" y1="424.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="34" length2="3"/>
         <line end1="none" end2="none" y1="432.3" antialias="false" y2="432.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="60" length1="3" x2="42" length2="3"/>
@@ -199,11 +199,11 @@
         <text x="-25" y="497.3" font="Liberation Sans,7,-1,5,75,0,0,0,0,0,Bold" rotation="0" color="#000000" text="BECKHOFF"/>
         <text x="-52" y="462.3" font="Liberation Sans,14,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
         <text x="-26" y="13" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
-        <terminal type="Generic" x="40" y="360" name="X04" uuid="{8301c6d7-608d-43c3-8c4b-dff9f4f67714}" orientation="e"/>
         <terminal type="Generic" x="40" y="120" name="X01" uuid="{d3bd70c9-25a0-45c6-b53d-d48eb21e382d}" orientation="e"/>
         <terminal type="Generic" x="40" y="280" name="X03" uuid="{097f479d-8668-4790-b20b-0ef00598f5ad}" orientation="e"/>
-        <terminal type="Generic" x="40" y="200" name="X02" uuid="{65cc4023-6fdf-4e19-a669-98fa2e38d411}" orientation="e"/>
         <terminal type="Generic" x="-40" y="40" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
         <terminal type="Generic" x="40" y="40" name="X51" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+        <terminal type="Generic" x="40" y="360" name="X04" uuid="{8301c6d7-608d-43c3-8c4b-dff9f4f67714}" orientation="e"/>
+        <terminal type="Generic" x="40" y="200" name="X02" uuid="{65cc4023-6fdf-4e19-a669-98fa2e38d411}" orientation="e"/>
     </description>
 </definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_126x30_8xm8a-3.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_126x30_8xm8a-3.elmt
@@ -1,5 +1,5 @@
 <definition type="element" link_type="simple" hotspot_x="35" hotspot_y="6" width="70" height="260" version="0.100.1">
-    <uuid uuid="{181d5d2c-5f31-4b19-afb0-fab8ab4358af}"/>
+    <uuid uuid="{93d2a8ff-721d-4bff-bce1-38404ba4038c}"/>
     <names>
         <name lang="de">EPPxxxx |1:1| 126,5x30mm | 8x M8-Buchse, 3-polig, A-kodiert</name>
         <name lang="en">EPPxxxx |1:1| 126.5x30mm | 8x M8-socket, 3-pol, a-coded</name>
@@ -135,32 +135,32 @@
         <line end1="none" end2="none" y1="135.51" antialias="false" y2="135.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.71" length1="3" x2="30.04" length2="3"/>
         <arc x="-21.61" y="-6.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="8" height="8" angle="45"/>
         <line end1="none" end2="none" y1="-0.06" antialias="false" y2="-1.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-14.78" length1="3" x2="-13.13" length2="3"/>
-        <arc x="13.7" y="246.11" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="161.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text>X07</text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="81.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text>X03</text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.5" y="181.4" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text>X08</text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="41.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text>X01</text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.54" y="141.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text>X06</text>
-        </dynamic_text>
         <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="121.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X05</text>
-        </dynamic_text>
-        <circle x="-0.96" y="167.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.5" y="101.4" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text>X04</text>
         </dynamic_text>
         <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.54" y="61.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X02</text>
         </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.5" y="181.4" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X08</text>
+        </dynamic_text>
+        <arc x="13.7" y="246.11" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.54" y="141.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X06</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="81.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X03</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="41.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X01</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="161.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X07</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.5" y="101.4" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X04</text>
+        </dynamic_text>
+        <circle x="-0.96" y="167.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
         <circle x="-3.96" y="187.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
         <circle x="-3.96" y="147.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
         <circle x="-1" y="127.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
@@ -170,6 +170,10 @@
         <line end1="none" end2="none" y1="133.71" antialias="false" y2="133.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="29.71" length2="3"/>
         <arc x="-14.3" y="-2.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
         <rect ry="7" x="-30" y="-3" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="60" height="253" rx="7"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-29" y="-30" z="141" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
+            <text></text>
+            <info_name>label</info_name>
+        </dynamic_text>
         <line end1="none" end2="none" y1="216" antialias="false" y2="216" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-30" length1="1.5" x2="-21" length2="1.5"/>
         <line end1="none" end2="none" y1="216" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-21" length1="1.5" x2="-17" length2="1.5"/>
         <line end1="none" end2="none" y1="212" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="17" length2="1.5"/>
@@ -186,15 +190,15 @@
         <text x="-13" y="247" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="BECKHOFF"/>
         <text x="-26" y="233" font="Liberation Sans,7,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
         <text x="-13" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
-        <terminal type="Generic" x="-20" y="130" name="X05" uuid="{89b91aef-ba1d-4b05-9753-1562d87b3246}" orientation="w"/>
-        <terminal type="Generic" x="-20" y="90" name="X03" uuid="{4e4a51e4-2c5c-4eda-8a2b-8c2f8ff5eeee}" orientation="w"/>
         <terminal type="Generic" x="-20" y="20" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
-        <terminal type="Generic" x="-20" y="170" name="X07" uuid="{14e34e66-542c-4270-8bb9-b8aa0c555d8c}" orientation="w"/>
-        <terminal type="Generic" x="20" y="190" name="X08" uuid="{89711b8f-a5ec-4df2-8c12-0fb01846d6de}" orientation="e"/>
         <terminal type="Generic" x="20" y="20" name="X51" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+        <terminal type="Generic" x="20" y="150" name="X06" uuid="{d3a83a40-932c-4101-9507-084e40e98956}" orientation="e"/>
+        <terminal type="Generic" x="20" y="190" name="X08" uuid="{89711b8f-a5ec-4df2-8c12-0fb01846d6de}" orientation="e"/>
+        <terminal type="Generic" x="-20" y="130" name="X05" uuid="{89b91aef-ba1d-4b05-9753-1562d87b3246}" orientation="w"/>
+        <terminal type="Generic" x="-20" y="170" name="X07" uuid="{14e34e66-542c-4270-8bb9-b8aa0c555d8c}" orientation="w"/>
         <terminal type="Generic" x="20" y="70" name="X02" uuid="{c905d889-7b5a-4d9e-8e4e-2770b5067a5f}" orientation="e"/>
         <terminal type="Generic" x="20" y="110" name="X04" uuid="{c39fd782-2d8f-4380-9539-87a10b0bc2f7}" orientation="e"/>
         <terminal type="Generic" x="-20" y="50" name="X01" uuid="{c4e93b46-7e00-4c88-a190-310603506254}" orientation="w"/>
-        <terminal type="Generic" x="20" y="150" name="X06" uuid="{d3a83a40-932c-4101-9507-084e40e98956}" orientation="e"/>
+        <terminal type="Generic" x="-20" y="90" name="X03" uuid="{4e4a51e4-2c5c-4eda-8a2b-8c2f8ff5eeee}" orientation="w"/>
     </description>
 </definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_126x30_8xm8a-3.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_126x30_8xm8a-3.elmt
@@ -1,5 +1,5 @@
 <definition type="element" link_type="simple" hotspot_x="35" hotspot_y="6" width="70" height="260" version="0.100.1">
-    <uuid uuid="{1d0f2846-11e4-4310-aded-23708b8f214d}"/>
+    <uuid uuid="{b09c9450-24d1-452c-b026-0fa5f9610aef}"/>
     <names>
         <name lang="de">EPPxxxx |1:1| 126,5x30mm | 8x M8-Buchse, 3-polig, A-kodiert</name>
         <name lang="en">EPPxxxx |1:1| 126.5x30mm | 8x M8-socket, 3-pol, a-coded</name>
@@ -125,15 +125,18 @@
         <circle x="15.42" y="21.48" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
         <circle x="-19.96" y="124.11" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="12"/>
         <circle x="-22.16" y="121.91" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.4"/>
+        <line end1="none" end2="none" y1="135.51" antialias="false" y2="135.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.71" length1="3" x2="30.04" length2="3"/>
+        <arc x="-21.61" y="-6.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="8" height="8" angle="45"/>
+        <line end1="none" end2="none" y1="-0.06" antialias="false" y2="-1.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-14.78" length1="3" x2="-13.13" length2="3"/>
         <dynamic_text frame="false" Halignment="AlignLeft" x="-17" y="233" z="120" rotation="0" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{4716c2f4-3f3a-441c-93c8-f90e91168538}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
             <text>EPP1008-0001</text>
             <info_name>designation</info_name>
         </dynamic_text>
-        <line end1="none" end2="none" y1="135.51" antialias="false" y2="135.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.71" length1="3" x2="30.04" length2="3"/>
-        <arc x="-21.61" y="-6.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="8" height="8" angle="45"/>
-        <line end1="none" end2="none" y1="-0.06" antialias="false" y2="-1.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-14.78" length1="3" x2="-13.13" length2="3"/>
         <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.54" y="61.5" z="124" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X02</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="195.4" z="125" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
         </dynamic_text>
         <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.5" y="181.4" z="125" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X08</text>
@@ -147,32 +150,32 @@
         <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="41.5" z="128" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X01</text>
         </dynamic_text>
+        <arc x="13.7" y="246.11" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
         <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="161.5" z="129" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X07</text>
         </dynamic_text>
+        <circle x="-0.96" y="167.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
         <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.5" y="101.4" z="130" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X04</text>
         </dynamic_text>
+        <circle x="-3.96" y="187.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-3.96" y="147.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
         <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="121.5" z="131" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X05</text>
         </dynamic_text>
-        <arc x="13.7" y="246.11" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
-        <circle x="-0.96" y="167.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
-        <circle x="-3.96" y="187.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
-        <circle x="-3.96" y="147.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
         <circle x="-1" y="127.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
         <circle x="2" y="9.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
         <circle x="-2.5" y="26.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
         <circle x="-7" y="9.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
         <line end1="none" end2="none" y1="133.71" antialias="false" y2="133.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="29.71" length2="3"/>
         <arc x="-14.3" y="-2.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="216" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-30" length1="1.5" x2="-21" length2="1.5"/>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-21" length1="1.5" x2="-17" length2="1.5"/>
+        <line end1="none" end2="none" y1="212" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="17" length2="1.5"/>
         <dynamic_text frame="false" Halignment="AlignLeft" x="-29" y="-30" z="142" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
             <text></text>
             <info_name>label</info_name>
         </dynamic_text>
-        <line end1="none" end2="none" y1="216" antialias="false" y2="216" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-30" length1="1.5" x2="-21" length2="1.5"/>
-        <line end1="none" end2="none" y1="216" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-21" length1="1.5" x2="-17" length2="1.5"/>
-        <line end1="none" end2="none" y1="212" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="17" length2="1.5"/>
         <line end1="none" end2="none" y1="216" antialias="false" y2="216" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="30" length1="1.5" x2="21" length2="1.5"/>
         <line end1="none" end2="none" y1="216" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="21" length1="1.5" x2="17" length2="1.5"/>
         <line end1="none" end2="none" y1="247.63" antialias="false" y2="249.63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="14.53" length1="3" x2="12.53" length2="3"/>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_126x30_8xm8a-3.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_126x30_8xm8a-3.elmt
@@ -1,5 +1,5 @@
 <definition type="element" link_type="simple" hotspot_x="35" hotspot_y="6" width="70" height="260" version="0.100.1">
-    <uuid uuid="{93d2a8ff-721d-4bff-bce1-38404ba4038c}"/>
+    <uuid uuid="{1d0f2846-11e4-4310-aded-23708b8f214d}"/>
     <names>
         <name lang="de">EPPxxxx |1:1| 126,5x30mm | 8x M8-Buchse, 3-polig, A-kodiert</name>
         <name lang="en">EPPxxxx |1:1| 126.5x30mm | 8x M8-socket, 3-pol, a-coded</name>
@@ -10,6 +10,7 @@
     </elementInformations>
     <informations>Author: Moritz Scholjegerdes</informations>
     <description>
+        <rect ry="7" x="-30" y="-3" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="60" height="253" rx="7"/>
         <text x="1" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="OUT"/>
         <rect ry="0" x="-27" y="65" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
         <rect ry="0" x="7" y="85" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
@@ -124,42 +125,38 @@
         <circle x="15.42" y="21.48" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
         <circle x="-19.96" y="124.11" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="12"/>
         <circle x="-22.16" y="121.91" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.4"/>
-        <line end1="none" end2="none" y1="30.71" antialias="false" y2="3.11" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.96" length1="3" x2="-29.96" length2="3"/>
-        <line end1="none" end2="none" y1="133.71" antialias="false" y2="32.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.96" length1="3" x2="-29.96" length2="3"/>
-        <line end1="none" end2="none" y1="135.51" antialias="false" y2="163.11" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="30.04" length2="3"/>
-        <line end1="none" end2="none" y1="32.51" antialias="false" y2="133.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="30.04" length2="3"/>
-        <dynamic_text frame="false" Halignment="AlignLeft" x="-17" y="233" z="119" rotation="0" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{4716c2f4-3f3a-441c-93c8-f90e91168538}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-17" y="233" z="120" rotation="0" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{4716c2f4-3f3a-441c-93c8-f90e91168538}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
             <text>EPP1008-0001</text>
             <info_name>designation</info_name>
         </dynamic_text>
         <line end1="none" end2="none" y1="135.51" antialias="false" y2="135.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.71" length1="3" x2="30.04" length2="3"/>
         <arc x="-21.61" y="-6.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="8" height="8" angle="45"/>
         <line end1="none" end2="none" y1="-0.06" antialias="false" y2="-1.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-14.78" length1="3" x2="-13.13" length2="3"/>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="121.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text>X05</text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.54" y="61.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.54" y="61.5" z="124" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X02</text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.5" y="181.4" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.5" y="181.4" z="125" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X08</text>
         </dynamic_text>
-        <arc x="13.7" y="246.11" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.54" y="141.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.54" y="141.5" z="126" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X06</text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="81.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="81.5" z="127" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X03</text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="41.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="41.5" z="128" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X01</text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="161.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="161.5" z="129" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X07</text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.5" y="101.4" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.5" y="101.4" z="130" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X04</text>
         </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="121.5" z="131" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X05</text>
+        </dynamic_text>
+        <arc x="13.7" y="246.11" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
         <circle x="-0.96" y="167.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
         <circle x="-3.96" y="187.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
         <circle x="-3.96" y="147.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
@@ -169,8 +166,7 @@
         <circle x="-7" y="9.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
         <line end1="none" end2="none" y1="133.71" antialias="false" y2="133.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="29.71" length2="3"/>
         <arc x="-14.3" y="-2.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
-        <rect ry="7" x="-30" y="-3" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="60" height="253" rx="7"/>
-        <dynamic_text frame="false" Halignment="AlignLeft" x="-29" y="-30" z="141" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-29" y="-30" z="142" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
             <text></text>
             <info_name>label</info_name>
         </dynamic_text>
@@ -190,15 +186,15 @@
         <text x="-13" y="247" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="BECKHOFF"/>
         <text x="-26" y="233" font="Liberation Sans,7,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
         <text x="-13" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
-        <terminal type="Generic" x="-20" y="20" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
+        <terminal type="Generic" x="20" y="70" name="X02" uuid="{c905d889-7b5a-4d9e-8e4e-2770b5067a5f}" orientation="e"/>
+        <terminal type="Generic" x="-20" y="50" name="X01" uuid="{c4e93b46-7e00-4c88-a190-310603506254}" orientation="w"/>
         <terminal type="Generic" x="20" y="20" name="X51" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
-        <terminal type="Generic" x="20" y="150" name="X06" uuid="{d3a83a40-932c-4101-9507-084e40e98956}" orientation="e"/>
-        <terminal type="Generic" x="20" y="190" name="X08" uuid="{89711b8f-a5ec-4df2-8c12-0fb01846d6de}" orientation="e"/>
+        <terminal type="Generic" x="-20" y="20" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
+        <terminal type="Generic" x="20" y="110" name="X04" uuid="{c39fd782-2d8f-4380-9539-87a10b0bc2f7}" orientation="e"/>
+        <terminal type="Generic" x="-20" y="90" name="X03" uuid="{4e4a51e4-2c5c-4eda-8a2b-8c2f8ff5eeee}" orientation="w"/>
         <terminal type="Generic" x="-20" y="130" name="X05" uuid="{89b91aef-ba1d-4b05-9753-1562d87b3246}" orientation="w"/>
         <terminal type="Generic" x="-20" y="170" name="X07" uuid="{14e34e66-542c-4270-8bb9-b8aa0c555d8c}" orientation="w"/>
-        <terminal type="Generic" x="20" y="70" name="X02" uuid="{c905d889-7b5a-4d9e-8e4e-2770b5067a5f}" orientation="e"/>
-        <terminal type="Generic" x="20" y="110" name="X04" uuid="{c39fd782-2d8f-4380-9539-87a10b0bc2f7}" orientation="e"/>
-        <terminal type="Generic" x="-20" y="50" name="X01" uuid="{c4e93b46-7e00-4c88-a190-310603506254}" orientation="w"/>
-        <terminal type="Generic" x="-20" y="90" name="X03" uuid="{4e4a51e4-2c5c-4eda-8a2b-8c2f8ff5eeee}" orientation="w"/>
+        <terminal type="Generic" x="20" y="150" name="X06" uuid="{d3a83a40-932c-4101-9507-084e40e98956}" orientation="e"/>
+        <terminal type="Generic" x="20" y="190" name="X08" uuid="{89711b8f-a5ec-4df2-8c12-0fb01846d6de}" orientation="e"/>
     </description>
 </definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_126x30_8xm8a-3.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_126x30_8xm8a-3.elmt
@@ -1,0 +1,200 @@
+<definition type="element" link_type="simple" hotspot_x="35" hotspot_y="6" width="70" height="260" version="0.100.1">
+    <uuid uuid="{181d5d2c-5f31-4b19-afb0-fab8ab4358af}"/>
+    <names>
+        <name lang="de">EPPxxxx |1:1| 126,5x30mm | 8x M8-Buchse, 3-polig, A-kodiert</name>
+        <name lang="en">EPPxxxx |1:1| 126.5x30mm | 8x M8-socket, 3-pol, a-coded</name>
+    </names>
+    <elementInformations>
+        <elementInformation name="designation" show="1">EPP1008-0001</elementInformation>
+        <elementInformation name="manufacturer" show="1">Beckhoff</elementInformation>
+    </elementInformations>
+    <informations>Author: Moritz Scholjegerdes</informations>
+    <description>
+        <text x="1" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="OUT"/>
+        <rect ry="0" x="-27" y="65" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <rect ry="0" x="7" y="85" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <arc x="-21.61" y="245.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="54.5" width="8" height="8" angle="24.8125"/>
+        <circle x="17.44" y="-1.49" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="11.2"/>
+        <rect ry="0" x="-27" y="105" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <circle x="15.19" y="66.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <rect ry="0" x="-27" y="145" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <line end1="none" end2="none" y1="247.06" antialias="false" y2="248.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-14.78" length1="3" x2="-13.13" length2="3"/>
+        <circle x="15.19" y="106.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <arc x="-14.3" y="241.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="8" height="8" angle="-45"/>
+        <circle x="10.23" y="106.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <rect ry="0" x="7" y="165" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <circle x="10.23" y="66.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <rect ry="0" x="-27" y="185" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <circle x="-12.88" y="91.19" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="10.23" y="71.04" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <arc x="-29" y="236" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="0" width="12" height="12" angle="90"/>
+        <rect ry="0" x="-27" y="199" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <circle x="10.23" y="111.04" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <line end1="none" end2="none" y1="236" antialias="false" y2="236" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-23" length1="1.5" x2="-30" length2="1.5"/>
+        <circle x="8.11" y="63.96" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="12"/>
+        <circle x="8.11" y="103.96" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="12"/>
+        <circle x="-22.36" y="11.71" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.8"/>
+        <circle x="5.91" y="101.76" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.4"/>
+        <line end1="none" end2="none" y1="243" antialias="false" y2="245.86" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="-17" length2="1.5"/>
+        <circle x="5.91" y="61.76" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.4"/>
+        <arc x="13.61" y="-6.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="234.5" width="8" height="8" angle="24.8125"/>
+        <circle x="-12.88" y="86.23" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="31.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-30" length1="1.5" x2="-21" length2="1.5"/>
+        <circle x="-17.84" y="86.23" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <line end1="none" end2="none" y1="-0.06" antialias="false" y2="-1.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="14.78" length1="3" x2="13.13" length2="3"/>
+        <circle x="-28.56" y="237.51" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="11.2"/>
+        <circle x="-12.88" y="51.19" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <arc x="6.3" y="-2.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="-45"/>
+        <circle x="-19.96" y="84.11" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="12"/>
+        <circle x="-26" y="240" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="6"/>
+        <circle x="-12.88" y="46.23" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="-17.84" y="46.23" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="15.19" y="146.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="-20.06" y="14.01" antialias="false" style="line-style:normal;line-weight:normal;filling:red;color:black" diameter="12.2"/>
+        <circle x="-22.16" y="81.91" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.4"/>
+        <circle x="15.19" y="186.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="-19.96" y="44.11" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="12"/>
+        <circle x="-22.16" y="41.91" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.4"/>
+        <circle x="10.23" y="186.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="-0.96" y="87.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="10.23" y="146.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="-3.96" y="107.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-12.88" y="171.19" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="10.23" y="151.04" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="-3.96" y="67.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <line end1="none" end2="none" y1="25.36" antialias="false" y2="24.41" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-15.99" length1="3" x2="-13.96" length2="3"/>
+        <circle x="-1" y="47.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="35.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-21" length1="1.5" x2="-17" length2="1.5"/>
+        <rect ry="0" x="7" y="45" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <circle x="10.23" y="191.04" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="8.11" y="143.96" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="12"/>
+        <circle x="16.04" y="203.41" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="8.11" y="183.96" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="12"/>
+        <line end1="none" end2="none" y1="24.41" antialias="false" y2="25.36" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-13.96" length1="3" x2="-11.92" length2="3"/>
+        <circle x="5.91" y="181.76" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.4"/>
+        <circle x="5.91" y="141.76" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.4"/>
+        <line end1="none" end2="none" y1="35.5" antialias="false" y2="35.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="31.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="30" length1="1.5" x2="21" length2="1.5"/>
+        <circle x="7.04" y="203.41" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-12.88" y="166.23" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="35.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="21" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="14.56" antialias="false" y2="15.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-13.18" length1="3" x2="-13.18" length2="3"/>
+        <arc x="-14.78" y="14.91" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="1.6" height="1.6" angle="180"/>
+        <circle x="-17.84" y="166.23" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <line end1="none" end2="none" y1="15.71" antialias="false" y2="14.57" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-14.78" length1="3" x2="-14.78" length2="3"/>
+        <circle x="-12.88" y="131.19" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="-19.96" y="164.11" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="12"/>
+        <circle x="-12.88" y="126.23" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="-17.84" y="126.23" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="-22.16" y="161.91" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.4"/>
+        <line end1="none" end2="none" y1="21.32" antialias="false" y2="20.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-13.36" length1="3" x2="-12.51" length2="3"/>
+        <line end1="none" end2="none" y1="22.71" antialias="false" y2="21.32" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-13.36" length1="3" x2="-13.36" length2="3"/>
+        <arc x="-14.56" y="22.11" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="1.2" height="1.2" angle="180"/>
+        <line end1="none" end2="none" y1="21.32" antialias="false" y2="22.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-14.56" length1="3" x2="-14.56" length2="3"/>
+        <line end1="none" end2="none" y1="20.61" antialias="false" y2="21.32" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-15.41" length1="3" x2="-14.56" length2="3"/>
+        <line end1="none" end2="none" y1="20.61" antialias="false" y2="20.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-16.26" length1="3" x2="-15.41" length2="3"/>
+        <arc x="-16.76" y="19.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="90" width="1" height="1" angle="180"/>
+        <line end1="none" end2="none" y1="19.61" antialias="false" y2="19.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-11.66" length1="3" x2="-16.26" length2="3"/>
+        <arc x="-12.16" y="19.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="270" width="1" height="1" angle="180"/>
+        <line end1="none" end2="none" y1="20.61" antialias="false" y2="20.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-12.51" length1="3" x2="-11.66" length2="3"/>
+        <circle x="-12.58" y="16.53" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-17.53" y="21.48" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-17.53" y="16.53" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="7.94" y="14.01" antialias="false" style="line-style:normal;line-weight:normal;filling:red;color:black" diameter="12.2"/>
+        <circle x="-12.58" y="21.48" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="5.64" y="11.71" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.8"/>
+        <line end1="none" end2="none" y1="25.36" antialias="false" y2="24.41" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="12.01" length1="3" x2="14.04" length2="3"/>
+        <line end1="none" end2="none" y1="24.41" antialias="false" y2="25.36" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="14.04" length1="3" x2="16.08" length2="3"/>
+        <line end1="none" end2="none" y1="14.56" antialias="false" y2="15.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="14.82" length1="3" x2="14.82" length2="3"/>
+        <arc x="13.22" y="14.91" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="1.6" height="1.6" angle="180"/>
+        <line end1="none" end2="none" y1="15.71" antialias="false" y2="14.57" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="13.22" length1="3" x2="13.22" length2="3"/>
+        <line end1="none" end2="none" y1="21.32" antialias="false" y2="20.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="14.64" length1="3" x2="15.49" length2="3"/>
+        <line end1="none" end2="none" y1="22.71" antialias="false" y2="21.32" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="14.64" length1="3" x2="14.64" length2="3"/>
+        <arc x="13.44" y="22.11" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="1.2" height="1.2" angle="180"/>
+        <line end1="none" end2="none" y1="21.32" antialias="false" y2="22.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="13.44" length1="3" x2="13.44" length2="3"/>
+        <line end1="none" end2="none" y1="20.61" antialias="false" y2="21.32" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="12.59" length1="3" x2="13.44" length2="3"/>
+        <line end1="none" end2="none" y1="20.61" antialias="false" y2="20.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="11.74" length1="3" x2="12.59" length2="3"/>
+        <arc x="11.24" y="19.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="90" width="1" height="1" angle="180"/>
+        <line end1="none" end2="none" y1="19.61" antialias="false" y2="19.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="16.34" length1="3" x2="11.74" length2="3"/>
+        <arc x="15.84" y="19.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="270" width="1" height="1" angle="180"/>
+        <line end1="none" end2="none" y1="20.61" antialias="false" y2="20.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="15.49" length1="3" x2="16.34" length2="3"/>
+        <circle x="15.42" y="16.53" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="10.47" y="21.48" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="10.47" y="16.53" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="15.42" y="21.48" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-19.96" y="124.11" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="12"/>
+        <circle x="-22.16" y="121.91" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.4"/>
+        <line end1="none" end2="none" y1="30.71" antialias="false" y2="3.11" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.96" length1="3" x2="-29.96" length2="3"/>
+        <line end1="none" end2="none" y1="133.71" antialias="false" y2="32.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.96" length1="3" x2="-29.96" length2="3"/>
+        <line end1="none" end2="none" y1="135.51" antialias="false" y2="163.11" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="30.04" length2="3"/>
+        <line end1="none" end2="none" y1="32.51" antialias="false" y2="133.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="30.04" length2="3"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-17" y="233" z="119" rotation="0" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{4716c2f4-3f3a-441c-93c8-f90e91168538}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
+            <text>EPP1008-0001</text>
+            <info_name>designation</info_name>
+        </dynamic_text>
+        <line end1="none" end2="none" y1="135.51" antialias="false" y2="135.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.71" length1="3" x2="30.04" length2="3"/>
+        <arc x="-21.61" y="-6.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="8" height="8" angle="45"/>
+        <line end1="none" end2="none" y1="-0.06" antialias="false" y2="-1.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-14.78" length1="3" x2="-13.13" length2="3"/>
+        <arc x="13.7" y="246.11" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="161.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X07</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="81.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X03</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.5" y="181.4" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X08</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="41.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X01</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.54" y="141.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X06</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="121.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X05</text>
+        </dynamic_text>
+        <circle x="-0.96" y="167.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.5" y="101.4" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X04</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.54" y="61.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X02</text>
+        </dynamic_text>
+        <circle x="-3.96" y="187.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-3.96" y="147.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-1" y="127.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="2" y="9.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-2.5" y="26.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-7" y="9.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <line end1="none" end2="none" y1="133.71" antialias="false" y2="133.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="29.71" length2="3"/>
+        <arc x="-14.3" y="-2.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
+        <rect ry="7" x="-30" y="-3" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="60" height="253" rx="7"/>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="216" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-30" length1="1.5" x2="-21" length2="1.5"/>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-21" length1="1.5" x2="-17" length2="1.5"/>
+        <line end1="none" end2="none" y1="212" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="216" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="30" length1="1.5" x2="21" length2="1.5"/>
+        <line end1="none" end2="none" y1="216" antialias="false" y2="212" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="21" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="247.63" antialias="false" y2="249.63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="14.53" length1="3" x2="12.53" length2="3"/>
+        <line end1="none" end2="none" y1="246.13" antialias="false" y2="246.11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="28.94" length1="3" x2="18.51" length2="3"/>
+        <line end1="none" end2="none" y1="1.11" antialias="false" y2="1.11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.14" length1="3" x2="-17.61" length2="3"/>
+        <circle x="20" y="1" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="6"/>
+        <rect ry="0" x="7" y="125" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <arc x="17" y="-1" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="180" width="12" height="12" angle="90"/>
+        <line end1="none" end2="none" y1="11" antialias="false" y2="11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="23" length1="1.5" x2="30" length2="1.5"/>
+        <line end1="none" end2="none" y1="4" antialias="false" y2="1.14" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="17" length1="1.5" x2="17" length2="1.5"/>
+        <text x="-13" y="247" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="BECKHOFF"/>
+        <text x="-26" y="233" font="Liberation Sans,7,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
+        <text x="-13" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
+        <terminal type="Generic" x="-20" y="130" name="X05" uuid="{89b91aef-ba1d-4b05-9753-1562d87b3246}" orientation="w"/>
+        <terminal type="Generic" x="-20" y="90" name="X03" uuid="{4e4a51e4-2c5c-4eda-8a2b-8c2f8ff5eeee}" orientation="w"/>
+        <terminal type="Generic" x="-20" y="20" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
+        <terminal type="Generic" x="-20" y="170" name="X07" uuid="{14e34e66-542c-4270-8bb9-b8aa0c555d8c}" orientation="w"/>
+        <terminal type="Generic" x="20" y="190" name="X08" uuid="{89711b8f-a5ec-4df2-8c12-0fb01846d6de}" orientation="e"/>
+        <terminal type="Generic" x="20" y="20" name="X51" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+        <terminal type="Generic" x="20" y="70" name="X02" uuid="{c905d889-7b5a-4d9e-8e4e-2770b5067a5f}" orientation="e"/>
+        <terminal type="Generic" x="20" y="110" name="X04" uuid="{c39fd782-2d8f-4380-9539-87a10b0bc2f7}" orientation="e"/>
+        <terminal type="Generic" x="-20" y="50" name="X01" uuid="{c4e93b46-7e00-4c88-a190-310603506254}" orientation="w"/>
+        <terminal type="Generic" x="20" y="150" name="X06" uuid="{d3a83a40-932c-4101-9507-084e40e98956}" orientation="e"/>
+    </description>
+</definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_126x30_8xm8a-3_x2.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_126x30_8xm8a-3_x2.elmt
@@ -1,5 +1,5 @@
 <definition type="element" link_type="simple" hotspot_x="65" hotspot_y="8" width="130" height="510" version="0.100.1">
-    <uuid uuid="{ce753e57-4cc7-4fb0-b516-8f45ed02cde8}"/>
+    <uuid uuid="{6dffa1ad-f9c6-48df-9fd6-fea7c25a6b44}"/>
     <names>
         <name lang="de">EPPxxxx |2:1| 126,5x30mm | 8x M8-Buchse, 3-polig, A-kodiert</name>
         <name lang="en">EPPxxxx |2:1| 126.5x30mm | 8x M8-socket, 3-pol, a-coded</name>
@@ -136,6 +136,9 @@
         <line end1="none" end2="none" y1="-0.12" antialias="false" y2="-3.44" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.56" length1="6" x2="-26.26" length2="6"/>
         <arc x="27.4" y="492.52" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="16" height="16" angle="45"/>
         <circle x="-1.92" y="335.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="394.5" z="124" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
+        </dynamic_text>
         <dynamic_text frame="false" Halignment="AlignHCenter" x="-50" y="368.5" z="124" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X08</text>
         </dynamic_text>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_126x30_8xm8a-3_x2.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_126x30_8xm8a-3_x2.elmt
@@ -1,5 +1,5 @@
 <definition type="element" link_type="simple" hotspot_x="65" hotspot_y="8" width="130" height="510" version="0.100.1">
-    <uuid uuid="{7fb4f62e-b09f-4b20-9858-18fecbd306f2}"/>
+    <uuid uuid="{593f9b97-05ed-4c54-91f4-c52d645cf292}"/>
     <names>
         <name lang="de">EPPxxxx |2:1| 126,5x30mm | 8x M8-Buchse, 3-polig, A-kodiert</name>
         <name lang="en">EPPxxxx |2:1| 126.5x30mm | 8x M8-socket, 3-pol, a-coded</name>
@@ -135,29 +135,29 @@
         <line end1="none" end2="none" y1="-0.12" antialias="false" y2="-3.44" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.56" length1="6" x2="-26.26" length2="6"/>
         <arc x="27.4" y="492.52" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="16" height="16" angle="45"/>
         <circle x="-1.92" y="335.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50" y="368.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text>X08</text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="88.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text>X01</text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50.08" y="288.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text>X06</text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50.08" y="128.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text>X02</text>
-        </dynamic_text>
         <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="248.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X05</text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="328.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text>X07</text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="168.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X03</text>
         </dynamic_text>
         <dynamic_text frame="false" Halignment="AlignHCenter" x="-50" y="208.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X04</text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="168.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text>X03</text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50.08" y="288.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X06</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="88.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X01</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50.08" y="128.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X02</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="328.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X07</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50" y="368.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X08</text>
         </dynamic_text>
         <circle x="-7.92" y="375.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
         <circle x="-7.92" y="295.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
@@ -169,6 +169,10 @@
         <arc x="-28.6" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="16" height="16" angle="45"/>
         <rect ry="14" x="-60" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="120" height="506" rx="14"/>
         <line end1="none" end2="none" y1="432.3" antialias="false" y2="432.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-60" length1="3" x2="-42" length2="3"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-49" y="-36" z="141" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
+            <text></text>
+            <info_name>label</info_name>
+        </dynamic_text>
         <line end1="none" end2="none" y1="432.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-42" length1="3" x2="-34" length2="3"/>
         <line end1="none" end2="none" y1="424.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="34" length2="3"/>
         <line end1="none" end2="none" y1="432.3" antialias="false" y2="432.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="60" length1="3" x2="42" length2="3"/>
@@ -184,15 +188,15 @@
         <text x="-25" y="497.3" font="Liberation Sans,7,-1,5,75,0,0,0,0,0,Bold" rotation="0" color="#000000" text="BECKHOFF"/>
         <text x="-52" y="462.3" font="Liberation Sans,14,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
         <text x="-26" y="13" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
+        <terminal type="Generic" x="40" y="140" name="X02" uuid="{93364ac4-dce2-4a27-b122-d99d0c237eff}" orientation="e"/>
+        <terminal type="Generic" x="-40" y="340" name="X07" uuid="{14e34e66-542c-4270-8bb9-b8aa0c555d8c}" orientation="w"/>
+        <terminal type="Generic" x="40" y="300" name="X06" uuid="{d3a83a40-932c-4101-9507-084e40e98956}" orientation="e"/>
+        <terminal type="Generic" x="-40" y="180" name="X03" uuid="{00d62ffe-60ad-46b0-80a0-d91b1976bd03}" orientation="w"/>
         <terminal type="Generic" x="40" y="220" name="X04" uuid="{7535446c-1331-4018-9c15-84c73b3afad1}" orientation="e"/>
         <terminal type="Generic" x="-40" y="100" name="X01" uuid="{1aed7cea-a56f-4024-8b7e-8f99767df3c2}" orientation="w"/>
         <terminal type="Generic" x="-40" y="40" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
-        <terminal type="Generic" x="40" y="300" name="X06" uuid="{d3a83a40-932c-4101-9507-084e40e98956}" orientation="e"/>
         <terminal type="Generic" x="-40" y="260" name="X05" uuid="{89b91aef-ba1d-4b05-9753-1562d87b3246}" orientation="w"/>
         <terminal type="Generic" x="40" y="380" name="X08" uuid="{89711b8f-a5ec-4df2-8c12-0fb01846d6de}" orientation="e"/>
         <terminal type="Generic" x="40" y="40" name="X51" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
-        <terminal type="Generic" x="40" y="140" name="X02" uuid="{93364ac4-dce2-4a27-b122-d99d0c237eff}" orientation="e"/>
-        <terminal type="Generic" x="-40" y="340" name="X07" uuid="{14e34e66-542c-4270-8bb9-b8aa0c555d8c}" orientation="w"/>
-        <terminal type="Generic" x="-40" y="180" name="X03" uuid="{00d62ffe-60ad-46b0-80a0-d91b1976bd03}" orientation="w"/>
     </description>
 </definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_126x30_8xm8a-3_x2.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_126x30_8xm8a-3_x2.elmt
@@ -1,5 +1,5 @@
 <definition type="element" link_type="simple" hotspot_x="65" hotspot_y="8" width="130" height="510" version="0.100.1">
-    <uuid uuid="{593f9b97-05ed-4c54-91f4-c52d645cf292}"/>
+    <uuid uuid="{ce753e57-4cc7-4fb0-b516-8f45ed02cde8}"/>
     <names>
         <name lang="de">EPPxxxx |2:1| 126,5x30mm | 8x M8-Buchse, 3-polig, A-kodiert</name>
         <name lang="en">EPPxxxx |2:1| 126.5x30mm | 8x M8-socket, 3-pol, a-coded</name>
@@ -10,6 +10,7 @@
     </elementInformations>
     <informations>Author: Moritz Scholjegerdes</informations>
     <description>
+        <rect ry="14" x="-60" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="120" height="506" rx="14"/>
         <rect ry="0" x="-54" y="130" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
         <text x="2" y="13" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="OUT"/>
         <arc x="-43.22" y="492.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="51.4375" width="16" height="16" angle="28.5"/>
@@ -128,36 +129,36 @@
         <line end1="none" end2="none" y1="271" antialias="false" y2="326.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="60.08" length2="6"/>
         <line end1="none" end2="none" y1="271" antialias="false" y2="271" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="59.42" length1="6" x2="60.08" length2="6"/>
         <arc x="-43.22" y="-13.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="16" height="16" angle="45"/>
-        <dynamic_text frame="false" Halignment="AlignLeft" x="-34" y="474.3" z="119" rotation="0" font="Liberation Sans,8,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{b5ec55a8-7f78-1b91-4ada-ed2333c17cda}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-34" y="474.3" z="120" rotation="0" font="Liberation Sans,8,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{b5ec55a8-7f78-1b91-4ada-ed2333c17cda}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
             <text>EPP1008-0001</text>
             <info_name>designation</info_name>
         </dynamic_text>
         <line end1="none" end2="none" y1="-0.12" antialias="false" y2="-3.44" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.56" length1="6" x2="-26.26" length2="6"/>
         <arc x="27.4" y="492.52" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="16" height="16" angle="45"/>
         <circle x="-1.92" y="335.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="248.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text>X05</text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50" y="368.5" z="124" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X08</text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="168.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text>X03</text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50" y="208.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text>X04</text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50.08" y="288.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text>X06</text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="88.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text>X01</text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50.08" y="128.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text>X02</text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="328.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="328.5" z="125" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X07</text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50" y="368.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text>X08</text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50.08" y="128.5" z="126" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X02</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="88.5" z="127" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X01</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50.08" y="288.5" z="128" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X06</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50" y="208.5" z="129" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X04</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="168.5" z="130" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X03</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="248.5" z="131" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X05</text>
         </dynamic_text>
         <circle x="-7.92" y="375.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
         <circle x="-7.92" y="295.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
@@ -167,7 +168,6 @@
         <circle x="-14" y="17.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
         <line end1="none" end2="none" y1="267.42" antialias="false" y2="267.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="59.42" length2="6"/>
         <arc x="-28.6" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="16" height="16" angle="45"/>
-        <rect ry="14" x="-60" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="120" height="506" rx="14"/>
         <line end1="none" end2="none" y1="432.3" antialias="false" y2="432.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-60" length1="3" x2="-42" length2="3"/>
         <dynamic_text frame="false" Halignment="AlignLeft" x="-49" y="-36" z="141" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
             <text></text>
@@ -188,15 +188,15 @@
         <text x="-25" y="497.3" font="Liberation Sans,7,-1,5,75,0,0,0,0,0,Bold" rotation="0" color="#000000" text="BECKHOFF"/>
         <text x="-52" y="462.3" font="Liberation Sans,14,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
         <text x="-26" y="13" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
-        <terminal type="Generic" x="40" y="140" name="X02" uuid="{93364ac4-dce2-4a27-b122-d99d0c237eff}" orientation="e"/>
-        <terminal type="Generic" x="-40" y="340" name="X07" uuid="{14e34e66-542c-4270-8bb9-b8aa0c555d8c}" orientation="w"/>
         <terminal type="Generic" x="40" y="300" name="X06" uuid="{d3a83a40-932c-4101-9507-084e40e98956}" orientation="e"/>
         <terminal type="Generic" x="-40" y="180" name="X03" uuid="{00d62ffe-60ad-46b0-80a0-d91b1976bd03}" orientation="w"/>
-        <terminal type="Generic" x="40" y="220" name="X04" uuid="{7535446c-1331-4018-9c15-84c73b3afad1}" orientation="e"/>
         <terminal type="Generic" x="-40" y="100" name="X01" uuid="{1aed7cea-a56f-4024-8b7e-8f99767df3c2}" orientation="w"/>
-        <terminal type="Generic" x="-40" y="40" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
         <terminal type="Generic" x="-40" y="260" name="X05" uuid="{89b91aef-ba1d-4b05-9753-1562d87b3246}" orientation="w"/>
         <terminal type="Generic" x="40" y="380" name="X08" uuid="{89711b8f-a5ec-4df2-8c12-0fb01846d6de}" orientation="e"/>
+        <terminal type="Generic" x="-40" y="340" name="X07" uuid="{14e34e66-542c-4270-8bb9-b8aa0c555d8c}" orientation="w"/>
+        <terminal type="Generic" x="40" y="140" name="X02" uuid="{93364ac4-dce2-4a27-b122-d99d0c237eff}" orientation="e"/>
+        <terminal type="Generic" x="40" y="220" name="X04" uuid="{7535446c-1331-4018-9c15-84c73b3afad1}" orientation="e"/>
         <terminal type="Generic" x="40" y="40" name="X51" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+        <terminal type="Generic" x="-40" y="40" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
     </description>
 </definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_126x30_8xm8a-3_x2.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_126x30_8xm8a-3_x2.elmt
@@ -1,0 +1,198 @@
+<definition type="element" link_type="simple" hotspot_x="65" hotspot_y="8" width="130" height="510" version="0.100.1">
+    <uuid uuid="{7fb4f62e-b09f-4b20-9858-18fecbd306f2}"/>
+    <names>
+        <name lang="de">EPPxxxx |2:1| 126,5x30mm | 8x M8-Buchse, 3-polig, A-kodiert</name>
+        <name lang="en">EPPxxxx |2:1| 126.5x30mm | 8x M8-socket, 3-pol, a-coded</name>
+    </names>
+    <elementInformations>
+        <elementInformation name="designation" show="1">EPP1008-0001</elementInformation>
+        <elementInformation name="manufacturer" show="1">Beckhoff</elementInformation>
+    </elementInformations>
+    <informations>Author: Moritz Scholjegerdes</informations>
+    <description>
+        <rect ry="0" x="-54" y="130" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <text x="2" y="13" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="OUT"/>
+        <arc x="-43.22" y="492.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="51.4375" width="16" height="16" angle="28.5"/>
+        <rect ry="0" x="14" y="170" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <circle x="34.88" y="-3" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="22.4"/>
+        <rect ry="0" x="-54" y="210" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <rect ry="0" x="-54" y="290" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <circle x="30.38" y="132.16" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <line end1="none" end2="none" y1="494.42" antialias="false" y2="497.74" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.56" length1="6" x2="-26.26" length2="6"/>
+        <circle x="30.38" y="212.16" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="20.46" y="212.16" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <arc x="-28.6" y="484.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="225" width="16" height="16" angle="45"/>
+        <circle x="20.46" y="132.16" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <rect ry="0" x="14" y="330" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <circle x="-25.76" y="182.38" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <rect ry="0" x="-54" y="370" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <circle x="20.46" y="142.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <arc x="-58" y="472.3" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="0" width="24" height="24" angle="90"/>
+        <rect ry="0" x="-54" y="396" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <circle x="20.46" y="222.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <line end1="none" end2="none" y1="472.3" antialias="false" y2="472.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-46" length1="3" x2="-60" length2="3"/>
+        <circle x="16.22" y="127.92" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="24"/>
+        <circle x="-44.72" y="23.42" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
+        <circle x="16.22" y="207.92" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="24"/>
+        <line end1="none" end2="none" y1="485.04" antialias="false" y2="492.02" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="-34" length2="3"/>
+        <circle x="11.82" y="203.52" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="32.8"/>
+        <arc x="27.22" y="-13.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="231.25" width="16" height="16" angle="28.6875"/>
+        <circle x="11.82" y="123.52" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="32.8"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-60" length1="3" x2="-42" length2="3"/>
+        <circle x="-25.76" y="172.46" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <line end1="none" end2="none" y1="-0.12" antialias="false" y2="-3.44" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="29.56" length1="6" x2="26.26" length2="6"/>
+        <circle x="-35.68" y="172.46" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="-25.76" y="102.38" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="-57.12" y="475.3" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="22.4"/>
+        <circle x="-39.92" y="168.22" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="24"/>
+        <arc x="12.6" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="45" width="16" height="16" angle="45"/>
+        <circle x="-52" y="480.3" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="12"/>
+        <circle x="-25.76" y="92.46" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="-35.68" y="92.46" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="30.38" y="292.16" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="-44.32" y="163.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="32.8"/>
+        <circle x="-40.12" y="28" antialias="false" style="line-style:normal;line-weight:normal;filling:red;color:black" diameter="24.4"/>
+        <circle x="-39.92" y="88.22" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="24"/>
+        <circle x="30.38" y="372.16" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="20.46" y="372.16" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="-44.32" y="83.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="32.8"/>
+        <circle x="-1.92" y="175.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="20.46" y="292.16" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="-7.92" y="215.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-25.76" y="342.38" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="20.46" y="302.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="-7.92" y="135.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <line end1="none" end2="none" y1="51.29" antialias="false" y2="48.82" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-32" length1="6" x2="-27.92" length2="6"/>
+        <circle x="-2" y="95" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <rect ry="0" x="14" y="90" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="71" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-42" length1="3" x2="-34" length2="3"/>
+        <circle x="20.46" y="382.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="16.22" y="287.92" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="24"/>
+        <circle x="32.08" y="404.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="16.22" y="367.92" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="24"/>
+        <line end1="none" end2="none" y1="48.82" antialias="false" y2="51.29" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-27.92" length1="6" x2="-23.84" length2="6"/>
+        <circle x="11.82" y="363.52" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="32.8"/>
+        <circle x="11.82" y="283.52" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="32.8"/>
+        <line end1="none" end2="none" y1="71" antialias="false" y2="71" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="60" length1="3" x2="42" length2="3"/>
+        <circle x="14.08" y="404.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-25.76" y="332.46" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="71" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="42" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="28" antialias="false" y2="31.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-26.36" length1="6" x2="-26.36" length2="6"/>
+        <arc x="-29.56" y="29.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="3.2" height="3.2" angle="180"/>
+        <circle x="-35.68" y="332.46" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <line end1="none" end2="none" y1="31.42" antialias="false" y2="28.03" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.56" length1="6" x2="-29.56" length2="6"/>
+        <circle x="-25.76" y="262.38" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="-39.92" y="328.22" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="24"/>
+        <circle x="-25.76" y="252.46" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="-35.68" y="252.46" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="-44.32" y="323.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="32.8"/>
+        <line end1="none" end2="none" y1="42.64" antialias="false" y2="41.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-26.72" length1="6" x2="-25" length2="6"/>
+        <line end1="none" end2="none" y1="45.42" antialias="false" y2="42.64" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-26.72" length1="6" x2="-26.72" length2="6"/>
+        <arc x="-29.12" y="44.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="2.4" height="2.4" angle="180"/>
+        <line end1="none" end2="none" y1="42.64" antialias="false" y2="45.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.12" length1="6" x2="-29.12" length2="6"/>
+        <line end1="none" end2="none" y1="41.22" antialias="false" y2="42.64" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-30.82" length1="6" x2="-29.12" length2="6"/>
+        <line end1="none" end2="none" y1="41.22" antialias="false" y2="41.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-32.52" length1="6" x2="-30.82" length2="6"/>
+        <arc x="-33.52" y="39.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="90" width="2" height="2" angle="180"/>
+        <line end1="none" end2="none" y1="39.22" antialias="false" y2="39.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-23.32" length1="6" x2="-32.52" length2="6"/>
+        <arc x="-24.32" y="39.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="270" width="2" height="2" angle="180"/>
+        <line end1="none" end2="none" y1="41.22" antialias="false" y2="41.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-25" length1="6" x2="-23.32" length2="6"/>
+        <circle x="-25.16" y="33.06" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-35.06" y="43" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-35.06" y="33.06" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="15.88" y="28" antialias="false" style="line-style:normal;line-weight:normal;filling:red;color:black" diameter="24.4"/>
+        <circle x="-25.16" y="43" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="11.28" y="23.42" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
+        <line end1="none" end2="none" y1="51.39" antialias="false" y2="48.82" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="24" length1="6" x2="28.08" length2="6"/>
+        <line end1="none" end2="none" y1="48.82" antialias="false" y2="51.39" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="28.08" length1="6" x2="32.16" length2="6"/>
+        <line end1="none" end2="none" y1="28.26" antialias="false" y2="31.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.64" length1="6" x2="29.64" length2="6"/>
+        <arc x="26.44" y="29.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="3.2" height="3.2" angle="180"/>
+        <line end1="none" end2="none" y1="31.42" antialias="false" y2="28.29" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="26.44" length1="6" x2="26.44" length2="6"/>
+        <line end1="none" end2="none" y1="42.64" antialias="false" y2="41.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.28" length1="6" x2="31" length2="6"/>
+        <line end1="none" end2="none" y1="45.42" antialias="false" y2="42.64" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.28" length1="6" x2="29.28" length2="6"/>
+        <arc x="26.88" y="44.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="2.4" height="2.4" angle="180"/>
+        <line end1="none" end2="none" y1="42.64" antialias="false" y2="45.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="26.88" length1="6" x2="26.88" length2="6"/>
+        <line end1="none" end2="none" y1="41.22" antialias="false" y2="42.64" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="25.18" length1="6" x2="26.88" length2="6"/>
+        <line end1="none" end2="none" y1="41.22" antialias="false" y2="41.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="23.48" length1="6" x2="25.18" length2="6"/>
+        <arc x="22.48" y="39.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="90" width="2" height="2" angle="180"/>
+        <line end1="none" end2="none" y1="39.22" antialias="false" y2="39.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="32.68" length1="6" x2="23.48" length2="6"/>
+        <arc x="31.68" y="39.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="270" width="2" height="2" angle="180"/>
+        <line end1="none" end2="none" y1="41.22" antialias="false" y2="41.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="31" length1="6" x2="32.68" length2="6"/>
+        <circle x="30.84" y="33.06" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="20.94" y="43" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="20.94" y="33.06" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="30.84" y="43" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-39.92" y="248.22" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="24"/>
+        <circle x="-44.32" y="243.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="32.8"/>
+        <line end1="none" end2="none" y1="427.42" antialias="false" y2="225" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-59.92" length1="6" x2="-59.92" length2="6"/>
+        <line end1="none" end2="none" y1="271" antialias="false" y2="326.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="60.08" length2="6"/>
+        <line end1="none" end2="none" y1="271" antialias="false" y2="271" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="59.42" length1="6" x2="60.08" length2="6"/>
+        <arc x="-43.22" y="-13.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="16" height="16" angle="45"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-34" y="474.3" z="119" rotation="0" font="Liberation Sans,8,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{b5ec55a8-7f78-1b91-4ada-ed2333c17cda}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
+            <text>EPP1008-0001</text>
+            <info_name>designation</info_name>
+        </dynamic_text>
+        <line end1="none" end2="none" y1="-0.12" antialias="false" y2="-3.44" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.56" length1="6" x2="-26.26" length2="6"/>
+        <arc x="27.4" y="492.52" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="16" height="16" angle="45"/>
+        <circle x="-1.92" y="335.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50" y="368.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X08</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="88.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X01</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50.08" y="288.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X06</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50.08" y="128.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X02</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="248.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X05</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="328.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X07</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50" y="208.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X04</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="168.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X03</text>
+        </dynamic_text>
+        <circle x="-7.92" y="375.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-7.92" y="295.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-2" y="255" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="4" y="17.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-5" y="53.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-14" y="17.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <line end1="none" end2="none" y1="267.42" antialias="false" y2="267.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="59.42" length2="6"/>
+        <arc x="-28.6" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="16" height="16" angle="45"/>
+        <rect ry="14" x="-60" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="120" height="506" rx="14"/>
+        <line end1="none" end2="none" y1="432.3" antialias="false" y2="432.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-60" length1="3" x2="-42" length2="3"/>
+        <line end1="none" end2="none" y1="432.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-42" length1="3" x2="-34" length2="3"/>
+        <line end1="none" end2="none" y1="424.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="432.3" antialias="false" y2="432.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="60" length1="3" x2="42" length2="3"/>
+        <line end1="none" end2="none" y1="432.3" antialias="false" y2="424.3" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="42" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="495.56" antialias="false" y2="499.56" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="29.06" length1="6" x2="25.06" length2="6"/>
+        <line end1="none" end2="none" y1="492.56" antialias="false" y2="492.53" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="57.88" length1="6" x2="36.02" length2="6"/>
+        <line end1="none" end2="none" y1="2.22" antialias="false" y2="2.22" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-58.28" length1="6" x2="-35.22" length2="6"/>
+        <circle x="40" y="2" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="12"/>
+        <rect ry="0" x="14" y="250" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <arc x="34" y="-2" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="180" width="24" height="24" angle="90"/>
+        <line end1="none" end2="none" y1="22" antialias="false" y2="22" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="46" length1="3" x2="60" length2="3"/>
+        <line end1="none" end2="none" y1="9" antialias="false" y2="2.28" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="34" length1="3" x2="34" length2="3"/>
+        <text x="-25" y="497.3" font="Liberation Sans,7,-1,5,75,0,0,0,0,0,Bold" rotation="0" color="#000000" text="BECKHOFF"/>
+        <text x="-52" y="462.3" font="Liberation Sans,14,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
+        <text x="-26" y="13" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
+        <terminal type="Generic" x="40" y="220" name="X04" uuid="{7535446c-1331-4018-9c15-84c73b3afad1}" orientation="e"/>
+        <terminal type="Generic" x="-40" y="100" name="X01" uuid="{1aed7cea-a56f-4024-8b7e-8f99767df3c2}" orientation="w"/>
+        <terminal type="Generic" x="-40" y="40" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
+        <terminal type="Generic" x="40" y="300" name="X06" uuid="{d3a83a40-932c-4101-9507-084e40e98956}" orientation="e"/>
+        <terminal type="Generic" x="-40" y="260" name="X05" uuid="{89b91aef-ba1d-4b05-9753-1562d87b3246}" orientation="w"/>
+        <terminal type="Generic" x="40" y="380" name="X08" uuid="{89711b8f-a5ec-4df2-8c12-0fb01846d6de}" orientation="e"/>
+        <terminal type="Generic" x="40" y="40" name="X51" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+        <terminal type="Generic" x="40" y="140" name="X02" uuid="{93364ac4-dce2-4a27-b122-d99d0c237eff}" orientation="e"/>
+        <terminal type="Generic" x="-40" y="340" name="X07" uuid="{14e34e66-542c-4270-8bb9-b8aa0c555d8c}" orientation="w"/>
+        <terminal type="Generic" x="-40" y="180" name="X03" uuid="{00d62ffe-60ad-46b0-80a0-d91b1976bd03}" orientation="w"/>
+    </description>
+</definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_86x30_4xm8a-3.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_86x30_4xm8a-3.elmt
@@ -1,5 +1,5 @@
 <definition type="element" link_type="simple" hotspot_x="35" hotspot_y="7" width="70" height="180" version="0.100.1">
-    <uuid uuid="{ed8c58b4-919f-435e-a9fd-9f0420588c79}"/>
+    <uuid uuid="{f9a68238-b678-49a6-af3e-b7fc64cc849a}"/>
     <names>
         <name lang="de">EPPxxxx |1:1| 86x30mm | 4x M8-Buchse, 3-polig, A-kodiert</name>
         <name lang="en">EPPxxxx |1:1| 86x30mm | 4x M8-socket, 3-pol, a-coded</name>
@@ -134,23 +134,27 @@
         </dynamic_text>
         <text x="-26" y="152" font="Liberation Sans,7,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
         <text x="-13" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.54" y="61.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X02</text>
+        </dynamic_text>
         <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="81.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X03</text>
-        </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.5" y="101.4" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text>X04</text>
         </dynamic_text>
         <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="41.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X01</text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.54" y="61.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
-            <text>X02</text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.5" y="101.4" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X04</text>
         </dynamic_text>
-        <terminal type="Generic" x="20" y="110" name="X04" uuid="{89711b8f-a5ec-4df2-8c12-0fb01846d6de}" orientation="e"/>
-        <terminal type="Generic" x="20" y="70" name="X02" uuid="{d3a83a40-932c-4101-9507-084e40e98956}" orientation="e"/>
-        <terminal type="Generic" x="-20" y="50" name="X01" uuid="{89b91aef-ba1d-4b05-9753-1562d87b3246}" orientation="w"/>
-        <terminal type="Generic" x="20" y="20" name="51" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-29" y="-30" z="141" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
+            <text></text>
+            <info_name>label</info_name>
+        </dynamic_text>
         <terminal type="Generic" x="-20" y="20" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
+        <terminal type="Generic" x="20" y="70" name="X02" uuid="{d3a83a40-932c-4101-9507-084e40e98956}" orientation="e"/>
+        <terminal type="Generic" x="20" y="20" name="51" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+        <terminal type="Generic" x="20" y="110" name="X04" uuid="{89711b8f-a5ec-4df2-8c12-0fb01846d6de}" orientation="e"/>
+        <terminal type="Generic" x="-20" y="50" name="X01" uuid="{89b91aef-ba1d-4b05-9753-1562d87b3246}" orientation="w"/>
         <terminal type="Generic" x="-20" y="90" name="X03" uuid="{14e34e66-542c-4270-8bb9-b8aa0c555d8c}" orientation="w"/>
     </description>
 </definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_86x30_4xm8a-3.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_86x30_4xm8a-3.elmt
@@ -1,5 +1,5 @@
 <definition type="element" link_type="simple" hotspot_x="35" hotspot_y="7" width="70" height="180" version="0.100.1">
-    <uuid uuid="{fa59bdea-f128-45d5-9d21-5a4d15efb089}"/>
+    <uuid uuid="{3fb554bd-079c-4ab2-a16a-b7cead80490e}"/>
     <names>
         <name lang="de">EPPxxxx |1:1| 86x30mm | 4x M8-Buchse, 3-polig, A-kodiert</name>
         <name lang="en">EPPxxxx |1:1| 86x30mm | 4x M8-socket, 3-pol, a-coded</name>
@@ -124,12 +124,12 @@
         <line end1="none" end2="none" y1="11" antialias="false" y2="11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="23" length1="1.5" x2="30" length2="1.5"/>
         <line end1="none" end2="none" y1="4" antialias="false" y2="1.14" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="17" length1="1.5" x2="17" length2="1.5"/>
         <text x="-13" y="166" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="BECKHOFF"/>
+        <text x="-26" y="152" font="Liberation Sans,7,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
+        <text x="-13" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
         <dynamic_text frame="false" Halignment="AlignLeft" x="-17" y="152" z="119" rotation="0" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{4716c2f4-3f3a-441c-93c8-f90e91168538}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
             <text>EPP1004-0061</text>
             <info_name>designation</info_name>
         </dynamic_text>
-        <text x="-26" y="152" font="Liberation Sans,7,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
-        <text x="-13" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
         <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.54" y="61.5" z="122" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X02</text>
         </dynamic_text>
@@ -141,6 +141,9 @@
         </dynamic_text>
         <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.5" y="101.4" z="125" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X04</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-21" y="114.4" z="125" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
         </dynamic_text>
         <dynamic_text frame="false" Halignment="AlignLeft" x="-29" y="-30" z="126" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
             <text></text>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_86x30_4xm8a-3.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_86x30_4xm8a-3.elmt
@@ -1,5 +1,5 @@
 <definition type="element" link_type="simple" hotspot_x="35" hotspot_y="7" width="70" height="180" version="0.100.1">
-    <uuid uuid="{f9a68238-b678-49a6-af3e-b7fc64cc849a}"/>
+    <uuid uuid="{fa59bdea-f128-45d5-9d21-5a4d15efb089}"/>
     <names>
         <name lang="de">EPPxxxx |1:1| 86x30mm | 4x M8-Buchse, 3-polig, A-kodiert</name>
         <name lang="en">EPPxxxx |1:1| 86x30mm | 4x M8-socket, 3-pol, a-coded</name>
@@ -10,6 +10,7 @@
     </elementInformations>
     <informations>Author: Moritz Scholjegerdes</informations>
     <description>
+        <rect ry="7" x="-30" y="-3" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="60" height="172" rx="7"/>
         <text x="1" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="OUT"/>
         <arc x="-21.61" y="164.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="54.5" width="8" height="8" angle="24.8125"/>
         <circle x="17.44" y="-1.49" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="11.2"/>
@@ -96,10 +97,6 @@
         <circle x="15.42" y="21.48" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
         <circle x="-19.96" y="44.11" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="12"/>
         <circle x="-22.16" y="41.91" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.4"/>
-        <line end1="none" end2="none" y1="30.71" antialias="false" y2="3.11" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.96" length1="3" x2="-29.96" length2="3"/>
-        <line end1="none" end2="none" y1="133.71" antialias="false" y2="32.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.96" length1="3" x2="-29.96" length2="3"/>
-        <line end1="none" end2="none" y1="135.51" antialias="false" y2="163.11" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="30.04" length2="3"/>
-        <line end1="none" end2="none" y1="32.51" antialias="false" y2="133.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="30.04" length2="3"/>
         <line end1="none" end2="none" y1="135.51" antialias="false" y2="135.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.71" length1="3" x2="30.04" length2="3"/>
         <arc x="-21.61" y="-6.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="8" height="8" angle="45"/>
         <line end1="none" end2="none" y1="-0.06" antialias="false" y2="-1.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-14.78" length1="3" x2="-13.13" length2="3"/>
@@ -113,7 +110,6 @@
         <circle x="-6.96" y="9.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
         <line end1="none" end2="none" y1="133.71" antialias="false" y2="133.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="29.71" length2="3"/>
         <arc x="-14.3" y="-2.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
-        <rect ry="7" x="-30" y="-3" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="60" height="172" rx="7"/>
         <line end1="none" end2="none" y1="135" antialias="false" y2="135" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-30" length1="1.5" x2="-21" length2="1.5"/>
         <line end1="none" end2="none" y1="135" antialias="false" y2="131" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-21" length1="1.5" x2="-17" length2="1.5"/>
         <line end1="none" end2="none" y1="131" antialias="false" y2="131" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="17" length2="1.5"/>
@@ -134,27 +130,27 @@
         </dynamic_text>
         <text x="-26" y="152" font="Liberation Sans,7,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
         <text x="-13" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.54" y="61.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.54" y="61.5" z="122" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X02</text>
         </dynamic_text>
         <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="81.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X03</text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="41.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="41.5" z="124" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X01</text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.5" y="101.4" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.5" y="101.4" z="125" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X04</text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignLeft" x="-29" y="-30" z="141" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-29" y="-30" z="126" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
             <text></text>
             <info_name>label</info_name>
         </dynamic_text>
-        <terminal type="Generic" x="-20" y="20" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
+        <terminal type="Generic" x="-20" y="90" name="X03" uuid="{14e34e66-542c-4270-8bb9-b8aa0c555d8c}" orientation="w"/>
         <terminal type="Generic" x="20" y="70" name="X02" uuid="{d3a83a40-932c-4101-9507-084e40e98956}" orientation="e"/>
+        <terminal type="Generic" x="-20" y="20" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
         <terminal type="Generic" x="20" y="20" name="51" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
         <terminal type="Generic" x="20" y="110" name="X04" uuid="{89711b8f-a5ec-4df2-8c12-0fb01846d6de}" orientation="e"/>
         <terminal type="Generic" x="-20" y="50" name="X01" uuid="{89b91aef-ba1d-4b05-9753-1562d87b3246}" orientation="w"/>
-        <terminal type="Generic" x="-20" y="90" name="X03" uuid="{14e34e66-542c-4270-8bb9-b8aa0c555d8c}" orientation="w"/>
     </description>
 </definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_86x30_4xm8a-3.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_86x30_4xm8a-3.elmt
@@ -1,0 +1,156 @@
+<definition type="element" link_type="simple" hotspot_x="35" hotspot_y="7" width="70" height="180" version="0.100.1">
+    <uuid uuid="{ed8c58b4-919f-435e-a9fd-9f0420588c79}"/>
+    <names>
+        <name lang="de">EPPxxxx |1:1| 86x30mm | 4x M8-Buchse, 3-polig, A-kodiert</name>
+        <name lang="en">EPPxxxx |1:1| 86x30mm | 4x M8-socket, 3-pol, a-coded</name>
+    </names>
+    <elementInformations>
+        <elementInformation name="designation" show="1">EPP1004-0061</elementInformation>
+        <elementInformation name="manufacturer" show="1">Beckhoff</elementInformation>
+    </elementInformations>
+    <informations>Author: Moritz Scholjegerdes</informations>
+    <description>
+        <text x="1" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="OUT"/>
+        <arc x="-21.61" y="164.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="54.5" width="8" height="8" angle="24.8125"/>
+        <circle x="17.44" y="-1.49" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="11.2"/>
+        <rect ry="0" x="-27" y="65" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <line end1="none" end2="none" y1="166.06" antialias="false" y2="167.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-14.78" length1="3" x2="-13.13" length2="3"/>
+        <arc x="-14.3" y="160.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="8" height="8" angle="-45"/>
+        <rect ry="0" x="7" y="85" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <rect ry="0" x="-27" y="105" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <arc x="-29" y="155" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="0" width="12" height="12" angle="90"/>
+        <rect ry="0" x="-27" y="118" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <line end1="none" end2="none" y1="155" antialias="false" y2="155" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-23" length1="1.5" x2="-30" length2="1.5"/>
+        <circle x="-22.36" y="11.71" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.8"/>
+        <line end1="none" end2="none" y1="162" antialias="false" y2="164.86" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="-17" length2="1.5"/>
+        <arc x="13.61" y="-6.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="234.5" width="8" height="8" angle="24.8125"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="31.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-30" length1="1.5" x2="-21" length2="1.5"/>
+        <line end1="none" end2="none" y1="-0.06" antialias="false" y2="-1.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="14.78" length1="3" x2="13.13" length2="3"/>
+        <circle x="-28.56" y="156.51" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="11.2"/>
+        <arc x="6.3" y="-2.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="-45"/>
+        <circle x="-26" y="159" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="6"/>
+        <circle x="15.19" y="66.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="-20.06" y="14.01" antialias="false" style="line-style:normal;line-weight:normal;filling:red;color:black" diameter="12.2"/>
+        <circle x="15.19" y="106.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="10.23" y="106.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="10.23" y="66.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="-12.88" y="91.19" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="10.23" y="71.04" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <line end1="none" end2="none" y1="25.36" antialias="false" y2="24.41" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-15.99" length1="3" x2="-13.96" length2="3"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="35.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-21" length1="1.5" x2="-17" length2="1.5"/>
+        <circle x="10.23" y="111.04" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="8.11" y="63.96" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="12"/>
+        <circle x="16.04" y="122.41" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="8.11" y="103.96" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="12"/>
+        <line end1="none" end2="none" y1="24.41" antialias="false" y2="25.36" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-13.96" length1="3" x2="-11.92" length2="3"/>
+        <circle x="5.91" y="101.76" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.4"/>
+        <circle x="5.91" y="61.76" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.4"/>
+        <line end1="none" end2="none" y1="35.5" antialias="false" y2="35.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="31.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="30" length1="1.5" x2="21" length2="1.5"/>
+        <circle x="7.04" y="122.41" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-12.88" y="86.23" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <line end1="none" end2="none" y1="31.5" antialias="false" y2="35.5" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="21" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="14.56" antialias="false" y2="15.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-13.18" length1="3" x2="-13.18" length2="3"/>
+        <arc x="-14.78" y="14.91" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="1.6" height="1.6" angle="180"/>
+        <circle x="-17.84" y="86.23" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <line end1="none" end2="none" y1="15.71" antialias="false" y2="14.57" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-14.78" length1="3" x2="-14.78" length2="3"/>
+        <circle x="-12.88" y="51.19" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="-19.96" y="84.11" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="12"/>
+        <circle x="-12.88" y="46.23" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="-17.84" y="46.23" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="2.8"/>
+        <circle x="-22.16" y="81.91" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.4"/>
+        <line end1="none" end2="none" y1="21.32" antialias="false" y2="20.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-13.36" length1="3" x2="-12.51" length2="3"/>
+        <line end1="none" end2="none" y1="22.71" antialias="false" y2="21.32" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-13.36" length1="3" x2="-13.36" length2="3"/>
+        <arc x="-14.56" y="22.11" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="1.2" height="1.2" angle="180"/>
+        <line end1="none" end2="none" y1="21.32" antialias="false" y2="22.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-14.56" length1="3" x2="-14.56" length2="3"/>
+        <line end1="none" end2="none" y1="20.61" antialias="false" y2="21.32" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-15.41" length1="3" x2="-14.56" length2="3"/>
+        <line end1="none" end2="none" y1="20.61" antialias="false" y2="20.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-16.26" length1="3" x2="-15.41" length2="3"/>
+        <arc x="-16.76" y="19.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="90" width="1" height="1" angle="180"/>
+        <line end1="none" end2="none" y1="19.61" antialias="false" y2="19.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-11.66" length1="3" x2="-16.26" length2="3"/>
+        <arc x="-12.16" y="19.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="270" width="1" height="1" angle="180"/>
+        <line end1="none" end2="none" y1="20.61" antialias="false" y2="20.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-12.51" length1="3" x2="-11.66" length2="3"/>
+        <circle x="-12.58" y="16.53" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-17.53" y="21.48" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-17.53" y="16.53" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="7.94" y="14.01" antialias="false" style="line-style:normal;line-weight:normal;filling:red;color:black" diameter="12.2"/>
+        <circle x="-12.58" y="21.48" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="5.64" y="11.71" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.8"/>
+        <line end1="none" end2="none" y1="25.36" antialias="false" y2="24.41" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="12.01" length1="3" x2="14.04" length2="3"/>
+        <line end1="none" end2="none" y1="24.41" antialias="false" y2="25.36" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="14.04" length1="3" x2="16.08" length2="3"/>
+        <line end1="none" end2="none" y1="14.56" antialias="false" y2="15.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="14.82" length1="3" x2="14.82" length2="3"/>
+        <arc x="13.22" y="14.91" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="1.6" height="1.6" angle="180"/>
+        <line end1="none" end2="none" y1="15.71" antialias="false" y2="14.57" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="13.22" length1="3" x2="13.22" length2="3"/>
+        <line end1="none" end2="none" y1="21.32" antialias="false" y2="20.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="14.64" length1="3" x2="15.49" length2="3"/>
+        <line end1="none" end2="none" y1="22.71" antialias="false" y2="21.32" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="14.64" length1="3" x2="14.64" length2="3"/>
+        <arc x="13.44" y="22.11" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="1.2" height="1.2" angle="180"/>
+        <line end1="none" end2="none" y1="21.32" antialias="false" y2="22.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="13.44" length1="3" x2="13.44" length2="3"/>
+        <line end1="none" end2="none" y1="20.61" antialias="false" y2="21.32" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="12.59" length1="3" x2="13.44" length2="3"/>
+        <line end1="none" end2="none" y1="20.61" antialias="false" y2="20.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="11.74" length1="3" x2="12.59" length2="3"/>
+        <arc x="11.24" y="19.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="90" width="1" height="1" angle="180"/>
+        <line end1="none" end2="none" y1="19.61" antialias="false" y2="19.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="16.34" length1="3" x2="11.74" length2="3"/>
+        <arc x="15.84" y="19.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="270" width="1" height="1" angle="180"/>
+        <line end1="none" end2="none" y1="20.61" antialias="false" y2="20.61" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="15.49" length1="3" x2="16.34" length2="3"/>
+        <circle x="15.42" y="16.53" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="10.47" y="21.48" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="10.47" y="16.53" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="15.42" y="21.48" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="2.2"/>
+        <circle x="-19.96" y="44.11" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="12"/>
+        <circle x="-22.16" y="41.91" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="16.4"/>
+        <line end1="none" end2="none" y1="30.71" antialias="false" y2="3.11" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.96" length1="3" x2="-29.96" length2="3"/>
+        <line end1="none" end2="none" y1="133.71" antialias="false" y2="32.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.96" length1="3" x2="-29.96" length2="3"/>
+        <line end1="none" end2="none" y1="135.51" antialias="false" y2="163.11" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="30.04" length2="3"/>
+        <line end1="none" end2="none" y1="32.51" antialias="false" y2="133.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="30.04" length2="3"/>
+        <line end1="none" end2="none" y1="135.51" antialias="false" y2="135.51" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.71" length1="3" x2="30.04" length2="3"/>
+        <arc x="-21.61" y="-6.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="8" height="8" angle="45"/>
+        <line end1="none" end2="none" y1="-0.06" antialias="false" y2="-1.72" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-14.78" length1="3" x2="-13.13" length2="3"/>
+        <arc x="13.7" y="165.11" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
+        <circle x="-0.96" y="87.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-3.96" y="107.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-3.96" y="67.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-1" y="47.5" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="2.04" y="9.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-2.46" y="26.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <circle x="-6.96" y="9.61" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="5"/>
+        <line end1="none" end2="none" y1="133.71" antialias="false" y2="133.71" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="30.04" length1="3" x2="29.71" length2="3"/>
+        <arc x="-14.3" y="-2.89" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="8" height="8" angle="45"/>
+        <rect ry="7" x="-30" y="-3" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="60" height="172" rx="7"/>
+        <line end1="none" end2="none" y1="135" antialias="false" y2="135" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-30" length1="1.5" x2="-21" length2="1.5"/>
+        <line end1="none" end2="none" y1="135" antialias="false" y2="131" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-21" length1="1.5" x2="-17" length2="1.5"/>
+        <line end1="none" end2="none" y1="131" antialias="false" y2="131" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-17" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="135" antialias="false" y2="135" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="30" length1="1.5" x2="21" length2="1.5"/>
+        <line end1="none" end2="none" y1="135" antialias="false" y2="131" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="21" length1="1.5" x2="17" length2="1.5"/>
+        <line end1="none" end2="none" y1="166.63" antialias="false" y2="168.63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="14.53" length1="3" x2="12.53" length2="3"/>
+        <line end1="none" end2="none" y1="165.13" antialias="false" y2="165.11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="28.94" length1="3" x2="18.51" length2="3"/>
+        <line end1="none" end2="none" y1="1.11" antialias="false" y2="1.11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.14" length1="3" x2="-17.61" length2="3"/>
+        <circle x="20" y="1" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="6"/>
+        <rect ry="0" x="7" y="45" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="20" height="10" rx="0"/>
+        <arc x="17" y="-1" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="180" width="12" height="12" angle="90"/>
+        <line end1="none" end2="none" y1="11" antialias="false" y2="11" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="23" length1="1.5" x2="30" length2="1.5"/>
+        <line end1="none" end2="none" y1="4" antialias="false" y2="1.14" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="17" length1="1.5" x2="17" length2="1.5"/>
+        <text x="-13" y="166" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="BECKHOFF"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-17" y="152" z="119" rotation="0" font="Liberation Sans,4,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{4716c2f4-3f3a-441c-93c8-f90e91168538}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
+            <text>EPP1004-0061</text>
+            <info_name>designation</info_name>
+        </dynamic_text>
+        <text x="-26" y="152" font="Liberation Sans,7,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
+        <text x="-13" y="6" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="81.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X03</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.5" y="101.4" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X04</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="6.5" y="41.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X01</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-27.54" y="61.5" z="123" rotation="0" font="Liberation Sans,5,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{1f1ab909-c398-4a3e-b3ee-20ca26a85ec8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X02</text>
+        </dynamic_text>
+        <terminal type="Generic" x="20" y="110" name="X04" uuid="{89711b8f-a5ec-4df2-8c12-0fb01846d6de}" orientation="e"/>
+        <terminal type="Generic" x="20" y="70" name="X02" uuid="{d3a83a40-932c-4101-9507-084e40e98956}" orientation="e"/>
+        <terminal type="Generic" x="-20" y="50" name="X01" uuid="{89b91aef-ba1d-4b05-9753-1562d87b3246}" orientation="w"/>
+        <terminal type="Generic" x="20" y="20" name="51" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+        <terminal type="Generic" x="-20" y="20" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
+        <terminal type="Generic" x="-20" y="90" name="X03" uuid="{14e34e66-542c-4270-8bb9-b8aa0c555d8c}" orientation="w"/>
+    </description>
+</definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_86x30_4xm8a-3_x2.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_86x30_4xm8a-3_x2.elmt
@@ -1,0 +1,156 @@
+<definition type="element" link_type="simple" hotspot_x="65" hotspot_y="9" width="130" height="350" version="0.100.1">
+    <uuid uuid="{22b40748-bf07-430d-95c3-5aa522a733c2}"/>
+    <names>
+        <name lang="de">EPPxxxx |2:1| 86x30mm | 4x M8-Buchse, 3-polig, A-kodiert</name>
+        <name lang="en">EPPxxxx |2:1| 86x30mm | 4x M8-socket, 3-pol, a-coded</name>
+    </names>
+    <elementInformations>
+        <elementInformation name="designation" show="1">EPP1004-0061</elementInformation>
+        <elementInformation name="manufacturer" show="1">Beckhoff</elementInformation>
+    </elementInformations>
+    <informations>Author: Moritz Scholjegerdes</informations>
+    <description>
+        <text x="2" y="13" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="OUT"/>
+        <arc x="-43.22" y="329.98" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="51.4375" width="16" height="16" angle="28.5"/>
+        <circle x="34.88" y="-3" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="22.4"/>
+        <rect ry="0" x="-54" y="130" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <line end1="none" end2="none" y1="332.32" antialias="false" y2="335.64" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.56" length1="6" x2="-26.26" length2="6"/>
+        <arc x="-28.6" y="321.98" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="225" width="16" height="16" angle="45"/>
+        <rect ry="0" x="14" y="170" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <rect ry="0" x="-54" y="210" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <arc x="-58" y="310" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="0" width="24" height="24" angle="90"/>
+        <rect ry="0" x="-54" y="236" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <line end1="none" end2="none" y1="310" antialias="false" y2="310" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-46" length1="3" x2="-60" length2="3"/>
+        <circle x="-44.72" y="23.42" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
+        <line end1="none" end2="none" y1="322.94" antialias="false" y2="329.92" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="-34" length2="3"/>
+        <arc x="27.22" y="-13.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="231.25" width="16" height="16" angle="28.6875"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-60" length1="3" x2="-42" length2="3"/>
+        <line end1="none" end2="none" y1="-0.12" antialias="false" y2="-3.44" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="29.56" length1="6" x2="26.26" length2="6"/>
+        <circle x="-57.12" y="313" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="22.4"/>
+        <arc x="12.6" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="45" width="16" height="16" angle="45"/>
+        <circle x="-52" y="318" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="12"/>
+        <circle x="30.38" y="132.16" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="-40.12" y="28" antialias="false" style="line-style:normal;line-weight:normal;filling:red;color:black" diameter="24.4"/>
+        <circle x="30.38" y="212.16" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="20.46" y="212.16" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="20.46" y="132.16" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="-25.76" y="182.38" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="20.46" y="142.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <line end1="none" end2="none" y1="51.29" antialias="false" y2="48.82" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-32" length1="6" x2="-27.92" length2="6"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="71" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-42" length1="3" x2="-34" length2="3"/>
+        <circle x="20.46" y="222.08" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="16.22" y="127.92" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="24"/>
+        <circle x="32.08" y="244.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="16.22" y="207.92" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="24"/>
+        <line end1="none" end2="none" y1="48.82" antialias="false" y2="51.29" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-27.92" length1="6" x2="-23.84" length2="6"/>
+        <circle x="11.82" y="203.52" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="32.8"/>
+        <circle x="11.82" y="123.52" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="32.8"/>
+        <line end1="none" end2="none" y1="71" antialias="false" y2="71" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="63" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="60" length1="3" x2="42" length2="3"/>
+        <circle x="14.08" y="244.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-25.76" y="172.46" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <line end1="none" end2="none" y1="63" antialias="false" y2="71" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="42" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="28" antialias="false" y2="31.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-26.36" length1="6" x2="-26.36" length2="6"/>
+        <arc x="-29.56" y="29.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="3.2" height="3.2" angle="180"/>
+        <circle x="-35.68" y="172.46" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <line end1="none" end2="none" y1="31.42" antialias="false" y2="28.03" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.56" length1="6" x2="-29.56" length2="6"/>
+        <circle x="-25.76" y="102.38" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="-39.92" y="168.22" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="24"/>
+        <circle x="-25.76" y="92.46" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="-35.68" y="92.46" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="5.6"/>
+        <circle x="-44.32" y="163.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="32.8"/>
+        <line end1="none" end2="none" y1="42.64" antialias="false" y2="41.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-26.72" length1="6" x2="-25" length2="6"/>
+        <line end1="none" end2="none" y1="45.42" antialias="false" y2="42.64" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-26.72" length1="6" x2="-26.72" length2="6"/>
+        <arc x="-29.12" y="44.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="2.4" height="2.4" angle="180"/>
+        <line end1="none" end2="none" y1="42.64" antialias="false" y2="45.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-29.12" length1="6" x2="-29.12" length2="6"/>
+        <line end1="none" end2="none" y1="41.22" antialias="false" y2="42.64" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-30.82" length1="6" x2="-29.12" length2="6"/>
+        <line end1="none" end2="none" y1="41.22" antialias="false" y2="41.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-32.52" length1="6" x2="-30.82" length2="6"/>
+        <arc x="-33.52" y="39.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="90" width="2" height="2" angle="180"/>
+        <line end1="none" end2="none" y1="39.22" antialias="false" y2="39.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-23.32" length1="6" x2="-32.52" length2="6"/>
+        <arc x="-24.32" y="39.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="270" width="2" height="2" angle="180"/>
+        <line end1="none" end2="none" y1="41.22" antialias="false" y2="41.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-25" length1="6" x2="-23.32" length2="6"/>
+        <circle x="-25.16" y="33.06" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-35.06" y="43" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-35.06" y="33.06" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="15.88" y="28" antialias="false" style="line-style:normal;line-weight:normal;filling:red;color:black" diameter="24.4"/>
+        <circle x="-25.16" y="43" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="11.28" y="23.42" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="33.6"/>
+        <line end1="none" end2="none" y1="51.39" antialias="false" y2="48.82" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="24" length1="6" x2="28.08" length2="6"/>
+        <line end1="none" end2="none" y1="48.82" antialias="false" y2="51.39" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="28.08" length1="6" x2="32.16" length2="6"/>
+        <line end1="none" end2="none" y1="28.26" antialias="false" y2="31.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.64" length1="6" x2="29.64" length2="6"/>
+        <arc x="26.44" y="29.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="3.2" height="3.2" angle="180"/>
+        <line end1="none" end2="none" y1="31.42" antialias="false" y2="28.29" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="26.44" length1="6" x2="26.44" length2="6"/>
+        <line end1="none" end2="none" y1="42.64" antialias="false" y2="41.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.28" length1="6" x2="31" length2="6"/>
+        <line end1="none" end2="none" y1="45.42" antialias="false" y2="42.64" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="29.28" length1="6" x2="29.28" length2="6"/>
+        <arc x="26.88" y="44.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="180" width="2.4" height="2.4" angle="180"/>
+        <line end1="none" end2="none" y1="42.64" antialias="false" y2="45.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="26.88" length1="6" x2="26.88" length2="6"/>
+        <line end1="none" end2="none" y1="41.22" antialias="false" y2="42.64" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="25.18" length1="6" x2="26.88" length2="6"/>
+        <line end1="none" end2="none" y1="41.22" antialias="false" y2="41.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="23.48" length1="6" x2="25.18" length2="6"/>
+        <arc x="22.48" y="39.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="90" width="2" height="2" angle="180"/>
+        <line end1="none" end2="none" y1="39.22" antialias="false" y2="39.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="32.68" length1="6" x2="23.48" length2="6"/>
+        <arc x="31.68" y="39.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" start="270" width="2" height="2" angle="180"/>
+        <line end1="none" end2="none" y1="41.22" antialias="false" y2="41.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="31" length1="6" x2="32.68" length2="6"/>
+        <circle x="30.84" y="33.06" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="20.94" y="43" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="20.94" y="33.06" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="30.84" y="43" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
+        <circle x="-39.92" y="88.22" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="24"/>
+        <circle x="-44.32" y="83.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="32.8"/>
+        <line end1="none" end2="none" y1="61.42" antialias="false" y2="6.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-59.92" length1="6" x2="-59.92" length2="6"/>
+        <line end1="none" end2="none" y1="267.42" antialias="false" y2="65" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-59.92" length1="6" x2="-59.92" length2="6"/>
+        <line end1="none" end2="none" y1="271" antialias="false" y2="326.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="60.08" length2="6"/>
+        <line end1="none" end2="none" y1="65" antialias="false" y2="267.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="60.08" length2="6"/>
+        <line end1="none" end2="none" y1="271" antialias="false" y2="271" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="59.42" length1="6" x2="60.08" length2="6"/>
+        <arc x="-43.22" y="-13.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="16" height="16" angle="45"/>
+        <line end1="none" end2="none" y1="-0.12" antialias="false" y2="-3.44" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.56" length1="6" x2="-26.26" length2="6"/>
+        <arc x="27.4" y="330.22" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="16" height="16" angle="45"/>
+        <circle x="-1.92" y="175.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-7.92" y="215.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-7.92" y="135.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-2" y="95" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="4.08" y="17.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-4.92" y="53.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <circle x="-13.92" y="17.22" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="10"/>
+        <line end1="none" end2="none" y1="267.42" antialias="false" y2="267.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="59.42" length2="6"/>
+        <arc x="-28.6" y="-5.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="90" width="16" height="16" angle="45"/>
+        <line end1="none" end2="none" y1="270" antialias="false" y2="270" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-60" length1="3" x2="-42" length2="3"/>
+        <line end1="none" end2="none" y1="270" antialias="false" y2="262" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-42" length1="3" x2="-34" length2="3"/>
+        <line end1="none" end2="none" y1="262" antialias="false" y2="262" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-34" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="270" antialias="false" y2="270" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="60" length1="3" x2="42" length2="3"/>
+        <line end1="none" end2="none" y1="270" antialias="false" y2="262" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="42" length1="3" x2="34" length2="3"/>
+        <line end1="none" end2="none" y1="333.26" antialias="false" y2="337.26" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="29.06" length1="6" x2="25.06" length2="6"/>
+        <line end1="none" end2="none" y1="330.26" antialias="false" y2="330.23" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="57.88" length1="6" x2="36.02" length2="6"/>
+        <line end1="none" end2="none" y1="2.22" antialias="false" y2="2.22" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-58.28" length1="6" x2="-35.22" length2="6"/>
+        <circle x="40" y="2" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="12"/>
+        <rect ry="0" x="14" y="90" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" width="40" height="20" rx="0"/>
+        <arc x="34" y="-2" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="180" width="24" height="24" angle="90"/>
+        <line end1="none" end2="none" y1="22" antialias="false" y2="22" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="46" length1="3" x2="60" length2="3"/>
+        <line end1="none" end2="none" y1="9" antialias="false" y2="2.28" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="34" length1="3" x2="34" length2="3"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-34" y="312" z="117" rotation="0" font="Liberation Sans,8,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{b5ec55a8-7f78-1b91-4ada-ed2333c17cda}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
+            <text>EPP1004-0061</text>
+            <info_name>designation</info_name>
+        </dynamic_text>
+        <text x="-25" y="335" font="Liberation Sans,7,-1,5,75,0,0,0,0,0,Bold" rotation="0" color="#000000" text="BECKHOFF"/>
+        <text x="-52" y="300" font="Liberation Sans,14,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
+        <text x="-26" y="13" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50" y="208.5" z="121" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X04</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="168.5" z="122" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X03</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50.08" y="128.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X02</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="88.5" z="124" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text>X01</text>
+        </dynamic_text>
+        <rect ry="14" x="-60" y="-5.96" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="120" height="344" rx="14"/>
+        <terminal type="Generic" x="40" y="140" name="X02" uuid="{d3a83a40-932c-4101-9507-084e40e98956}" orientation="e"/>
+        <terminal type="Generic" x="-40" y="40" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
+        <terminal type="Generic" x="-40" y="180" name="X03" uuid="{14e34e66-542c-4270-8bb9-b8aa0c555d8c}" orientation="w"/>
+        <terminal type="Generic" x="40" y="40" name="X51" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+        <terminal type="Generic" x="40" y="220" name="X04" uuid="{89711b8f-a5ec-4df2-8c12-0fb01846d6de}" orientation="e"/>
+        <terminal type="Generic" x="-40" y="100" name="X01" uuid="{89b91aef-ba1d-4b05-9753-1562d87b3246}" orientation="w"/>
+    </description>
+</definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_86x30_4xm8a-3_x2.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_86x30_4xm8a-3_x2.elmt
@@ -1,5 +1,5 @@
 <definition type="element" link_type="simple" hotspot_x="65" hotspot_y="9" width="130" height="350" version="0.100.1">
-    <uuid uuid="{22b40748-bf07-430d-95c3-5aa522a733c2}"/>
+    <uuid uuid="{e3a3590b-ef2f-4f09-8e04-1313042f4732}"/>
     <names>
         <name lang="de">EPPxxxx |2:1| 86x30mm | 4x M8-Buchse, 3-polig, A-kodiert</name>
         <name lang="en">EPPxxxx |2:1| 86x30mm | 4x M8-socket, 3-pol, a-coded</name>
@@ -146,11 +146,15 @@
             <text>X01</text>
         </dynamic_text>
         <rect ry="14" x="-60" y="-5.96" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="120" height="344" rx="14"/>
-        <terminal type="Generic" x="40" y="140" name="X02" uuid="{d3a83a40-932c-4101-9507-084e40e98956}" orientation="e"/>
-        <terminal type="Generic" x="-40" y="40" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-49" y="-36" z="141" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
+            <text></text>
+            <info_name>label</info_name>
+        </dynamic_text>
         <terminal type="Generic" x="-40" y="180" name="X03" uuid="{14e34e66-542c-4270-8bb9-b8aa0c555d8c}" orientation="w"/>
-        <terminal type="Generic" x="40" y="40" name="X51" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+        <terminal type="Generic" x="-40" y="40" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
+        <terminal type="Generic" x="40" y="140" name="X02" uuid="{d3a83a40-932c-4101-9507-084e40e98956}" orientation="e"/>
         <terminal type="Generic" x="40" y="220" name="X04" uuid="{89711b8f-a5ec-4df2-8c12-0fb01846d6de}" orientation="e"/>
+        <terminal type="Generic" x="40" y="40" name="X51" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
         <terminal type="Generic" x="-40" y="100" name="X01" uuid="{89b91aef-ba1d-4b05-9753-1562d87b3246}" orientation="w"/>
     </description>
 </definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_86x30_4xm8a-3_x2.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_86x30_4xm8a-3_x2.elmt
@@ -1,5 +1,5 @@
 <definition type="element" link_type="simple" hotspot_x="65" hotspot_y="9" width="130" height="350" version="0.100.1">
-    <uuid uuid="{e3a3590b-ef2f-4f09-8e04-1313042f4732}"/>
+    <uuid uuid="{064a570f-1a93-457f-8c92-7347222dfb21}"/>
     <names>
         <name lang="de">EPPxxxx |2:1| 86x30mm | 4x M8-Buchse, 3-polig, A-kodiert</name>
         <name lang="en">EPPxxxx |2:1| 86x30mm | 4x M8-socket, 3-pol, a-coded</name>
@@ -10,6 +10,7 @@
     </elementInformations>
     <informations>Author: Moritz Scholjegerdes</informations>
     <description>
+        <rect ry="14" x="-60" y="-5.96" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="120" height="344" rx="14"/>
         <text x="2" y="13" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="OUT"/>
         <arc x="-43.22" y="329.98" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="51.4375" width="16" height="16" angle="28.5"/>
         <circle x="34.88" y="-3" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="22.4"/>
@@ -96,10 +97,6 @@
         <circle x="30.84" y="43" antialias="false" style="line-style:normal;line-weight:normal;filling:white;color:black" diameter="4.4"/>
         <circle x="-39.92" y="88.22" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" diameter="24"/>
         <circle x="-44.32" y="83.82" antialias="false" style="line-style:normal;line-weight:thin;filling:none;color:black" diameter="32.8"/>
-        <line end1="none" end2="none" y1="61.42" antialias="false" y2="6.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-59.92" length1="6" x2="-59.92" length2="6"/>
-        <line end1="none" end2="none" y1="267.42" antialias="false" y2="65" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="-59.92" length1="6" x2="-59.92" length2="6"/>
-        <line end1="none" end2="none" y1="271" antialias="false" y2="326.22" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="60.08" length2="6"/>
-        <line end1="none" end2="none" y1="65" antialias="false" y2="267.42" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="60.08" length1="6" x2="60.08" length2="6"/>
         <line end1="none" end2="none" y1="271" antialias="false" y2="271" style="line-style:normal;line-weight:thin;filling:none;color:black" x1="59.42" length1="6" x2="60.08" length2="6"/>
         <arc x="-43.22" y="-13.78" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" start="270" width="16" height="16" angle="45"/>
         <line end1="none" end2="none" y1="-0.12" antialias="false" y2="-3.44" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="-29.56" length1="6" x2="-26.26" length2="6"/>
@@ -126,35 +123,34 @@
         <arc x="34" y="-2" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="180" width="24" height="24" angle="90"/>
         <line end1="none" end2="none" y1="22" antialias="false" y2="22" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="46" length1="3" x2="60" length2="3"/>
         <line end1="none" end2="none" y1="9" antialias="false" y2="2.28" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="34" length1="3" x2="34" length2="3"/>
-        <dynamic_text frame="false" Halignment="AlignLeft" x="-34" y="312" z="117" rotation="0" font="Liberation Sans,8,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{b5ec55a8-7f78-1b91-4ada-ed2333c17cda}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-34" y="312" z="118" rotation="0" font="Liberation Sans,8,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{b5ec55a8-7f78-1b91-4ada-ed2333c17cda}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
             <text>EPP1004-0061</text>
             <info_name>designation</info_name>
         </dynamic_text>
         <text x="-25" y="335" font="Liberation Sans,7,-1,5,75,0,0,0,0,0,Bold" rotation="0" color="#000000" text="BECKHOFF"/>
         <text x="-52" y="300" font="Liberation Sans,14,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
         <text x="-26" y="13" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50" y="208.5" z="121" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50" y="208.5" z="122" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X04</text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="168.5" z="122" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="168.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X03</text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50.08" y="128.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-50.08" y="128.5" z="124" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{50941ce2-02a8-9a5e-b1eb-866698998ac8}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X02</text>
         </dynamic_text>
-        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="88.5" z="124" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="88.5" z="125" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{d9778764-c954-e780-dde9-18d878531f8f}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X01</text>
         </dynamic_text>
-        <rect ry="14" x="-60" y="-5.96" antialias="false" style="line-style:normal;line-weight:normal;filling:none;color:black" width="120" height="344" rx="14"/>
-        <dynamic_text frame="false" Halignment="AlignLeft" x="-49" y="-36" z="141" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
+        <dynamic_text frame="false" Halignment="AlignLeft" x="-49" y="-36" z="126" rotation="0" font="Liberation Sans,9,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{91dbb6d8-82ae-46f6-8ccf-ecb7cc28e649}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignTop">
             <text></text>
             <info_name>label</info_name>
         </dynamic_text>
-        <terminal type="Generic" x="-40" y="180" name="X03" uuid="{14e34e66-542c-4270-8bb9-b8aa0c555d8c}" orientation="w"/>
         <terminal type="Generic" x="-40" y="40" name="X50" uuid="{75498e4e-3c0c-4372-bf99-597f46fb8248}" orientation="w"/>
         <terminal type="Generic" x="40" y="140" name="X02" uuid="{d3a83a40-932c-4101-9507-084e40e98956}" orientation="e"/>
-        <terminal type="Generic" x="40" y="220" name="X04" uuid="{89711b8f-a5ec-4df2-8c12-0fb01846d6de}" orientation="e"/>
-        <terminal type="Generic" x="40" y="40" name="X51" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
         <terminal type="Generic" x="-40" y="100" name="X01" uuid="{89b91aef-ba1d-4b05-9753-1562d87b3246}" orientation="w"/>
+        <terminal type="Generic" x="-40" y="180" name="X03" uuid="{14e34e66-542c-4270-8bb9-b8aa0c555d8c}" orientation="w"/>
+        <terminal type="Generic" x="40" y="40" name="X51" uuid="{b19c0e9d-b81d-4ae4-85b7-436002cce9c4}" orientation="e"/>
+        <terminal type="Generic" x="40" y="220" name="X04" uuid="{89711b8f-a5ec-4df2-8c12-0fb01846d6de}" orientation="e"/>
     </description>
 </definition>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_86x30_4xm8a-3_x2.elmt
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/epp_86x30_4xm8a-3_x2.elmt
@@ -1,5 +1,5 @@
 <definition type="element" link_type="simple" hotspot_x="65" hotspot_y="9" width="130" height="350" version="0.100.1">
-    <uuid uuid="{064a570f-1a93-457f-8c92-7347222dfb21}"/>
+    <uuid uuid="{dd199557-6e66-4df2-a27e-1313cce6e224}"/>
     <names>
         <name lang="de">EPPxxxx |2:1| 86x30mm | 4x M8-Buchse, 3-polig, A-kodiert</name>
         <name lang="en">EPPxxxx |2:1| 86x30mm | 4x M8-socket, 3-pol, a-coded</name>
@@ -123,15 +123,18 @@
         <arc x="34" y="-2" antialias="true" style="line-style:normal;line-weight:normal;filling:none;color:black" start="180" width="24" height="24" angle="90"/>
         <line end1="none" end2="none" y1="22" antialias="false" y2="22" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="46" length1="3" x2="60" length2="3"/>
         <line end1="none" end2="none" y1="9" antialias="false" y2="2.28" style="line-style:normal;line-weight:normal;filling:none;color:black" x1="34" length1="3" x2="34" length2="3"/>
+        <text x="-25" y="335" font="Liberation Sans,7,-1,5,75,0,0,0,0,0,Bold" rotation="0" color="#000000" text="BECKHOFF"/>
+        <text x="-52" y="300" font="Liberation Sans,14,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
+        <text x="-26" y="13" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
         <dynamic_text frame="false" Halignment="AlignLeft" x="-34" y="312" z="118" rotation="0" font="Liberation Sans,8,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{b5ec55a8-7f78-1b91-4ada-ed2333c17cda}" keep_visual_rotation="false" text_from="ElementInfo" Valignment="AlignVCenter">
             <text>EPP1004-0061</text>
             <info_name>designation</info_name>
         </dynamic_text>
-        <text x="-25" y="335" font="Liberation Sans,7,-1,5,75,0,0,0,0,0,Bold" rotation="0" color="#000000" text="BECKHOFF"/>
-        <text x="-52" y="300" font="Liberation Sans,14,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="EtherCAT P"/>
-        <text x="-26" y="13" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" rotation="0" color="#000000" text="IN"/>
         <dynamic_text frame="false" Halignment="AlignHCenter" x="-50" y="208.5" z="122" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X04</text>
+        </dynamic_text>
+        <dynamic_text frame="false" Halignment="AlignHCenter" x="-38.5" y="234.5" z="122" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{f29ddb67-1ebd-c00a-5dbd-4fe05322d7e4}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
+            <text></text>
         </dynamic_text>
         <dynamic_text frame="false" Halignment="AlignHCenter" x="18" y="168.5" z="123" rotation="0" font="Liberation Sans,10,-1,0,50,0,0,0,0,0,Regular" text_width="-1" uuid="{e9ab2009-f508-7131-729c-ac0e4f3398f7}" keep_visual_rotation="false" text_from="UserText" Valignment="AlignVCenter">
             <text>X03</text>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/qet_directory
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_box/qet_directory
@@ -1,0 +1,8 @@
+<qet-directory>
+    <names>
+        <name lang="cs">EtherCAT Box</name>
+        <name lang="de">EtherCAT Box</name>
+        <name lang="en">EtherCAT Box</name>
+        <name lang="ko">EtherCAT Box</name>
+    </names>
+</qet-directory>


### PR DESCRIPTION
I have added several Beckhoff EtherCAT and EtherCAT-P boxes, creating them in two different sizes.
The standard version (1:1 scale) uses a ratio of 100 mm to 200 pixels. 
The second version is scaled up by a factor of 2 to improve text readability.

<img width="2082" height="954" alt="grafik" src="https://github.com/user-attachments/assets/c1d22a10-3215-4310-aa3c-d207783557a7" />
