### PR TITLE
Seed IEC 81346-2 designation-letter on 291 well-evidenced categories

### DIFF
--- a/10_electric/10_allpole/114_connections/qet_directory
+++ b/10_electric/10_allpole/114_connections/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Spojení</name>
         <name lang="da">Forbindelser</name>

--- a/10_electric/10_allpole/120_cables_wiring/qet_directory
+++ b/10_electric/10_allpole/120_cables_wiring/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="W">
     <names>
         <name lang="cs">Kabely a vodiče</name>
         <name lang="da">Kabler og ledninger</name>

--- a/10_electric/10_allpole/130_terminals_terminal_strips/90_terminal_strips_diagram/qet_directory
+++ b/10_electric/10_allpole/130_terminals_terminal_strips/90_terminal_strips_diagram/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Výkres svorkovnic</name>
         <name lang="da">Klemmerækker</name>

--- a/10_electric/10_allpole/130_terminals_terminal_strips/95_terminals_spring_box/qet_directory
+++ b/10_electric/10_allpole/130_terminals_terminal_strips/95_terminals_spring_box/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="W">
     <names>
         <name lang="cs">Svorkové bloky</name>
         <name lang="de">Hebelklemmen</name>

--- a/10_electric/10_allpole/130_terminals_terminal_strips/qet_directory
+++ b/10_electric/10_allpole/130_terminals_terminal_strips/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="U">
     <names>
         <name lang="ar">طرفيات توصيل</name>
         <name lang="cs">Svorky</name>

--- a/10_electric/10_allpole/140_connectors_plugs/01_connectors_pins/qet_directory
+++ b/10_electric/10_allpole/140_connectors_plugs/01_connectors_pins/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Konektorové piny</name>
         <name lang="da">Stik ben</name>

--- a/10_electric/10_allpole/140_connectors_plugs/10_connectors_circular/qet_directory
+++ b/10_electric/10_allpole/140_connectors_plugs/10_connectors_circular/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Kulaté konektory</name>
         <name lang="da">Runde stik</name>

--- a/10_electric/10_allpole/140_connectors_plugs/15_connectors_dsub/qet_directory
+++ b/10_electric/10_allpole/140_connectors_plugs/15_connectors_dsub/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Konektory D-Sub</name>
         <name lang="da">Stik D-sub</name>

--- a/10_electric/10_allpole/140_connectors_plugs/20_socket_outlets/qet_directory
+++ b/10_electric/10_allpole/140_connectors_plugs/20_socket_outlets/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Zásuvky napájecí</name>
         <name lang="da">Stik udtag</name>

--- a/10_electric/10_allpole/140_connectors_plugs/60_connectors_electronics/qet_directory
+++ b/10_electric/10_allpole/140_connectors_plugs/60_connectors_electronics/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Kontakty do plošných spojů</name>
         <name lang="da">Electronik forbindelser</name>

--- a/10_electric/10_allpole/200_fuses_protective_gears/10_fuses/qet_directory
+++ b/10_electric/10_allpole/200_fuses_protective_gears/10_fuses/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="F">
     <names>
         <name lang="ar">حوامل-مصهرات</name>
         <name lang="cs">Pojistky</name>

--- a/10_electric/10_allpole/200_fuses_protective_gears/11_circuit_breakers/qet_directory
+++ b/10_electric/10_allpole/200_fuses_protective_gears/11_circuit_breakers/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="Q">
     <names>
         <name lang="ar">قواطع</name>
         <name lang="cs">Jističe</name>

--- a/10_electric/10_allpole/200_fuses_protective_gears/12_magneto_thermal_circuit_breakers/qet_directory
+++ b/10_electric/10_allpole/200_fuses_protective_gears/12_magneto_thermal_circuit_breakers/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="Q">
     <names>
         <name lang="ar">GV قواطع مغناطسية-حرارية</name>
         <name lang="cs">Motorové spouštěče</name>

--- a/10_electric/10_allpole/200_fuses_protective_gears/20_disconnecting_switches/qet_directory
+++ b/10_electric/10_allpole/200_fuses_protective_gears/20_disconnecting_switches/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="ar">عازلات</name>
         <name lang="cs">Odpínače</name>

--- a/10_electric/10_allpole/200_fuses_protective_gears/30_thermal_relays/qet_directory
+++ b/10_electric/10_allpole/200_fuses_protective_gears/30_thermal_relays/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="F">
     <names>
         <name lang="ar">مُرحلات حرارية</name>
         <name lang="cs">Tepelná relé</name>

--- a/10_electric/10_allpole/200_fuses_protective_gears/50_residual_current_circuit_breaker/qet_directory
+++ b/10_electric/10_allpole/200_fuses_protective_gears/50_residual_current_circuit_breaker/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="Q">
     <names>
         <name lang="ar">قواطع تفاضلية</name>
         <name lang="cs">Proudové chrániče</name>

--- a/10_electric/10_allpole/200_fuses_protective_gears/90_overvoltage_protections/qet_directory
+++ b/10_electric/10_allpole/200_fuses_protective_gears/90_overvoltage_protections/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="F">
     <names>
         <name lang="cs">Přepěťové ochrany</name>
         <name lang="da">Overspændingsbeskyttelse</name>

--- a/10_electric/10_allpole/310_relays_contactors_contacts/01_coils/qet_directory
+++ b/10_electric/10_allpole/310_relays_contactors_contacts/01_coils/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="ar">لفه</name>
         <name lang="ca">bobina</name>

--- a/10_electric/10_allpole/310_relays_contactors_contacts/02_contacts_cross_referencing/01_auxiliary_contacts/qet_directory
+++ b/10_electric/10_allpole/310_relays_contactors_contacts/02_contacts_cross_referencing/01_auxiliary_contacts/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="Q">
     <names>
         <name lang="cs">Pomocné kontakty</name>
         <name lang="da">Hjælpe kontakter</name>

--- a/10_electric/10_allpole/310_relays_contactors_contacts/02_contacts_cross_referencing/02_power_contacts/qet_directory
+++ b/10_electric/10_allpole/310_relays_contactors_contacts/02_contacts_cross_referencing/02_power_contacts/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="Q">
     <names>
         <name lang="ar">قدرة</name>
         <name lang="cs">Silové kontakty</name>

--- a/10_electric/10_allpole/310_relays_contactors_contacts/02_contacts_cross_referencing/11_delayed_contacts/qet_directory
+++ b/10_electric/10_allpole/310_relays_contactors_contacts/02_contacts_cross_referencing/11_delayed_contacts/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="Q">
     <names>
         <name lang="ar">مؤقتة</name>
         <name lang="cs">Zpožděné kontakty</name>

--- a/10_electric/10_allpole/310_relays_contactors_contacts/02_contacts_cross_referencing/15_protection_contacts/qet_directory
+++ b/10_electric/10_allpole/310_relays_contactors_contacts/02_contacts_cross_referencing/15_protection_contacts/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="F">
     <names>
         <name lang="ar">حمايات</name>
         <name lang="cs">Ochrany</name>

--- a/10_electric/10_allpole/310_relays_contactors_contacts/03_contacts/qet_directory
+++ b/10_electric/10_allpole/310_relays_contactors_contacts/03_contacts/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="Q">
     <names>
         <name lang="ar">جهات الاتصال</name>
         <name lang="ca">Contactes</name>

--- a/10_electric/10_allpole/330_transformers_power_supplies/10_transformers/qet_directory
+++ b/10_electric/10_allpole/330_transformers_power_supplies/10_transformers/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="T">
     <names>
         <name lang="ar">مُحوّلات</name>
         <name lang="cs">Transformátory</name>

--- a/10_electric/10_allpole/330_transformers_power_supplies/30_power_supplies/qet_directory
+++ b/10_electric/10_allpole/330_transformers_power_supplies/30_power_supplies/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="T">
     <names>
         <name lang="cs">Napájecí zdroje</name>
         <name lang="da">Strømforsyninger</name>

--- a/10_electric/10_allpole/330_transformers_power_supplies/40_uninterruptible_power_supply/qet_directory
+++ b/10_electric/10_allpole/330_transformers_power_supplies/40_uninterruptible_power_supply/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="G">
     <names>
         <name lang="cs">Záložní napájecí zdroje</name>
         <name lang="da">Nødstrømsforsyning</name>

--- a/10_electric/10_allpole/340_converters_inverters/10_converters/qet_directory
+++ b/10_electric/10_allpole/340_converters_inverters/10_converters/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="T">
     <names>
         <name lang="ar">مُحوّلات الكترونيات القدرة</name>
         <name lang="cs">Měniče</name>

--- a/10_electric/10_allpole/340_converters_inverters/15_measuring_transducers/qet_directory
+++ b/10_electric/10_allpole/340_converters_inverters/15_measuring_transducers/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="T">
     <names>
         <name lang="cs">Převodníky</name>
         <name lang="de">Messumformer</name>

--- a/10_electric/10_allpole/340_converters_inverters/20_current_tansformers/qet_directory
+++ b/10_electric/10_allpole/340_converters_inverters/20_current_tansformers/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="T">
     <names>
         <name lang="cs">Transformátory proudu</name>
         <name lang="de">Stromwandler</name>

--- a/10_electric/10_allpole/340_converters_inverters/90_filters/almeto/qet_directory
+++ b/10_electric/10_allpole/340_converters_inverters/90_filters/almeto/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="T">
     <names>
         <name lang="cs">Almeto</name>
         <name lang="de">Almeto</name>

--- a/10_electric/10_allpole/340_converters_inverters/90_filters/qet_directory
+++ b/10_electric/10_allpole/340_converters_inverters/90_filters/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="H">
     <names>
         <name lang="cs">Filtry</name>
         <name lang="de">Filter</name>

--- a/10_electric/10_allpole/340_converters_inverters/90_filters/schurter/qet_directory
+++ b/10_electric/10_allpole/340_converters_inverters/90_filters/schurter/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="H">
     <names>
         <name lang="cs">Schurter</name>
         <name lang="de">Schurter</name>

--- a/10_electric/10_allpole/380_signaling_operating/11_optical_signaling/qet_directory
+++ b/10_electric/10_allpole/380_signaling_operating/11_optical_signaling/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="E">
     <names>
         <name lang="cs">Světelná signalizace</name>
         <name lang="de">Optische Meldeeinrichtungen</name>

--- a/10_electric/10_allpole/380_signaling_operating/12_acoustic_signaling/qet_directory
+++ b/10_electric/10_allpole/380_signaling_operating/12_acoustic_signaling/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="E">
     <names>
         <name lang="cs">Akustická signalizace</name>
         <name lang="de">Akustische Meldeeinrichtungen</name>

--- a/10_electric/10_allpole/380_signaling_operating/20_push_buttons/qet_directory
+++ b/10_electric/10_allpole/380_signaling_operating/20_push_buttons/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="ar">مفاتيح ضاغطة</name>
         <name lang="cs">Tlačítka</name>

--- a/10_electric/10_allpole/380_signaling_operating/21_selector_switches/qet_directory
+++ b/10_electric/10_allpole/380_signaling_operating/21_selector_switches/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="cs">Přepínače, voliče</name>
         <name lang="de">Wahlschalter</name>

--- a/10_electric/10_allpole/380_signaling_operating/25_lever_switches/qet_directory
+++ b/10_electric/10_allpole/380_signaling_operating/25_lever_switches/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="cs">Páky a páčky</name>
         <name lang="de">Hebelschalter</name>

--- a/10_electric/10_allpole/390_sensors_instruments/01_sensors_capacitive/qet_directory
+++ b/10_electric/10_allpole/390_sensors_instruments/01_sensors_capacitive/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="ar">حسّاسات سعوية</name>
         <name lang="cs">Kapacitní snímače</name>

--- a/10_electric/10_allpole/390_sensors_instruments/02_sensors_inductive/qet_directory
+++ b/10_electric/10_allpole/390_sensors_instruments/02_sensors_inductive/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="ar">حسّسات حثيّة</name>
         <name lang="cs">Indukční snímače</name>

--- a/10_electric/10_allpole/390_sensors_instruments/03_sensors_magnetic/qet_directory
+++ b/10_electric/10_allpole/390_sensors_instruments/03_sensors_magnetic/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="ar">حسّاسات مغناطيسية</name>
         <name lang="cs">Magnetické snímače</name>

--- a/10_electric/10_allpole/390_sensors_instruments/04_sensors_optical/qet_directory
+++ b/10_electric/10_allpole/390_sensors_instruments/04_sensors_optical/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="ar">حسّاسات بصرية</name>
         <name lang="cs">Optické snímače</name>

--- a/10_electric/10_allpole/390_sensors_instruments/11_sensors_flow/qet_directory
+++ b/10_electric/10_allpole/390_sensors_instruments/11_sensors_flow/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="cs">Průtokové snímače</name>
         <name lang="de">Sensoren Durchfluss</name>

--- a/10_electric/10_allpole/390_sensors_instruments/12_sensors_level/qet_directory
+++ b/10_electric/10_allpole/390_sensors_instruments/12_sensors_level/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="cs">Hladinové spínače</name>
         <name lang="de">Sensoren Niveau</name>

--- a/10_electric/10_allpole/390_sensors_instruments/13_sensors_pressure/qet_directory
+++ b/10_electric/10_allpole/390_sensors_instruments/13_sensors_pressure/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="cs">Tlakové spínače</name>
         <name lang="de">Sensoren Druck</name>

--- a/10_electric/10_allpole/390_sensors_instruments/14_sensors_humidity/qet_directory
+++ b/10_electric/10_allpole/390_sensors_instruments/14_sensors_humidity/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="cs">Spínače vlhkosti</name>
         <name lang="de">Sensoren Feuchte</name>

--- a/10_electric/10_allpole/390_sensors_instruments/15_sensors_temperature/qet_directory
+++ b/10_electric/10_allpole/390_sensors_instruments/15_sensors_temperature/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="cs">Snímače teploty</name>
         <name lang="de">Temperatur-Sensoren</name>

--- a/10_electric/10_allpole/390_sensors_instruments/16_sensors_ultrasonic/qet_directory
+++ b/10_electric/10_allpole/390_sensors_instruments/16_sensors_ultrasonic/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="ar">حسّاسات فوق صوتيّة</name>
         <name lang="cs">Ultrazvukové snímače</name>

--- a/10_electric/10_allpole/390_sensors_instruments/41_limit_switches/qet_directory
+++ b/10_electric/10_allpole/390_sensors_instruments/41_limit_switches/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="ar">مفاتيح حدّ</name>
         <name lang="cs">Koncové spínače</name>

--- a/10_electric/10_allpole/390_sensors_instruments/60_timers/qet_directory
+++ b/10_electric/10_allpole/390_sensors_instruments/60_timers/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Časové spínače</name>
         <name lang="de">Zeitschalter</name>

--- a/10_electric/10_allpole/390_sensors_instruments/70_meters_measuring_indicators/qet_directory
+++ b/10_electric/10_allpole/390_sensors_instruments/70_meters_measuring_indicators/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="P">
     <names>
         <name lang="ar">عدّادات</name>
         <name lang="cs">Měřiče a indikátory</name>

--- a/10_electric/10_allpole/390_sensors_instruments/80_encoder/qet_directory
+++ b/10_electric/10_allpole/390_sensors_instruments/80_encoder/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="cs">Enkodéry</name>
         <name lang="de">Wegmessung / Encoder</name>

--- a/10_electric/10_allpole/391_consumers_actuators/10_engines/qet_directory
+++ b/10_electric/10_allpole/391_consumers_actuators/10_engines/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="M">
     <names>
         <name lang="ar">محرّك</name>
         <name lang="cs">Motory a aktuátory</name>

--- a/10_electric/10_allpole/391_consumers_actuators/20_valves/qet_directory
+++ b/10_electric/10_allpole/391_consumers_actuators/20_valves/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="M">
     <names>
         <name lang="cs">Elektroventily</name>
         <name lang="de">Ventile</name>

--- a/10_electric/10_allpole/391_consumers_actuators/30_brakes/qet_directory
+++ b/10_electric/10_allpole/391_consumers_actuators/30_brakes/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="M">
     <names>
         <name lang="cs">Brzdy</name>
         <name lang="de">Bremsen</name>

--- a/10_electric/10_allpole/391_consumers_actuators/50_heatings/qet_directory
+++ b/10_electric/10_allpole/391_consumers_actuators/50_heatings/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="M">
     <names>
         <name lang="cs">Výkonové odpory</name>
         <name lang="de">Heizungen</name>

--- a/10_electric/10_allpole/391_consumers_actuators/60_lightings/qet_directory
+++ b/10_electric/10_allpole/391_consumers_actuators/60_lightings/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="E">
     <names>
         <name lang="cs">Osvětlení</name>
         <name lang="de">Beleuchtungen</name>

--- a/10_electric/10_allpole/391_consumers_actuators/70_servomoteur/qet_directory
+++ b/10_electric/10_allpole/391_consumers_actuators/70_servomoteur/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="M">
     <names>
         <name lang="cs">Servomotory</name>
         <name lang="de">Servomotoren</name>

--- a/10_electric/10_allpole/392_generators_sources/10_generators/qet_directory
+++ b/10_electric/10_allpole/392_generators_sources/10_generators/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="G">
     <names>
         <name lang="cs">Generátory</name>
         <name lang="de">Generatoren</name>

--- a/10_electric/10_allpole/392_generators_sources/20_power_units/qet_directory
+++ b/10_electric/10_allpole/392_generators_sources/20_power_units/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="G">
     <names>
         <name lang="cs">Elektrocentrály</name>
         <name lang="de">Stromaggregate</name>

--- a/10_electric/10_allpole/392_generators_sources/30_batteries/qet_directory
+++ b/10_electric/10_allpole/392_generators_sources/30_batteries/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="G">
     <names>
         <name lang="cs">Baterie</name>
         <name lang="de">Batterien</name>

--- a/10_electric/10_allpole/392_generators_sources/70_voltage_current_sources/qet_directory
+++ b/10_electric/10_allpole/392_generators_sources/70_voltage_current_sources/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="G">
     <names>
         <name lang="cs">Zdroje napětí a proudu</name>
         <name lang="de">Spannungs- und Stromquellen</name>

--- a/10_electric/10_allpole/395_electronics_semiconductors/01_resistors/qet_directory
+++ b/10_electric/10_allpole/395_electronics_semiconductors/01_resistors/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="ar">مُقاومة</name>
         <name lang="cs">Odpory</name>

--- a/10_electric/10_allpole/395_electronics_semiconductors/02_capacitors/qet_directory
+++ b/10_electric/10_allpole/395_electronics_semiconductors/02_capacitors/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="C">
     <names>
         <name lang="ar">مُكثّف</name>
         <name lang="cs">Kondenzátory</name>

--- a/10_electric/10_allpole/395_electronics_semiconductors/03_inductors/qet_directory
+++ b/10_electric/10_allpole/395_electronics_semiconductors/03_inductors/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="R">
     <names>
         <name lang="cs">Cívky</name>
         <name lang="de">Induktivitäten</name>

--- a/10_electric/10_allpole/395_electronics_semiconductors/09_disturbances/qet_directory
+++ b/10_electric/10_allpole/395_electronics_semiconductors/09_disturbances/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="R">
     <names>
         <name lang="ar">طُفيليّة</name>
         <name lang="cs">Neosazené díly</name>

--- a/10_electric/10_allpole/395_electronics_semiconductors/11_diodes/qet_directory
+++ b/10_electric/10_allpole/395_electronics_semiconductors/11_diodes/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Diody</name>
         <name lang="de">Dioden</name>

--- a/10_electric/10_allpole/395_electronics_semiconductors/12_transistors/qet_directory
+++ b/10_electric/10_allpole/395_electronics_semiconductors/12_transistors/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="ar">ترنزيستور</name>
         <name lang="cs">Tranzistory</name>

--- a/10_electric/10_allpole/395_electronics_semiconductors/13_thyristors/qet_directory
+++ b/10_electric/10_allpole/395_electronics_semiconductors/13_thyristors/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="ar">ثايريستور</name>
         <name lang="cs">Tyristory</name>

--- a/10_electric/10_allpole/395_electronics_semiconductors/24piezo/qet_directory
+++ b/10_electric/10_allpole/395_electronics_semiconductors/24piezo/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Piezo</name>
         <name lang="de">Piezo</name>

--- a/10_electric/10_allpole/395_electronics_semiconductors/31_integrated_circuits/qet_directory
+++ b/10_electric/10_allpole/395_electronics_semiconductors/31_integrated_circuits/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="ar">دوائر مدمجة</name>
         <name lang="cs">Integrované obvody</name>

--- a/10_electric/10_allpole/395_electronics_semiconductors/41_PLC_controllers/qet_directory
+++ b/10_electric/10_allpole/395_electronics_semiconductors/41_PLC_controllers/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">PLC a kontroléry</name>
         <name lang="de">SPS und Steuerungen</name>

--- a/10_electric/10_allpole/395_electronics_semiconductors/91_computer_science/qet_directory
+++ b/10_electric/10_allpole/395_electronics_semiconductors/91_computer_science/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Výpočetní technika</name>
         <name lang="de">Computertechnik</name>

--- a/10_electric/10_allpole/450_high_voltage/qet_directory
+++ b/10_electric/10_allpole/450_high_voltage/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="ar">جهد عالي</name>
         <name lang="cs">Vysoké napětí</name>

--- a/10_electric/10_allpole/500_home_installation/20_home_appliances/qet_directory
+++ b/10_electric/10_allpole/500_home_installation/20_home_appliances/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="ar">أجهزة</name>
         <name lang="cs">Spotřebiče</name>

--- a/10_electric/10_allpole/500_home_installation/40_meters/qet_directory
+++ b/10_electric/10_allpole/500_home_installation/40_meters/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="P">
     <names>
         <name lang="ar">عدّادات</name>
         <name lang="cs">Měřiče</name>

--- a/10_electric/11_singlepole/140_connectors_plugs/qet_directory
+++ b/10_electric/11_singlepole/140_connectors_plugs/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Konektory a zástrčky</name>
         <name lang="de">Stecker und Buchsen</name>

--- a/10_electric/11_singlepole/200_fuses_protective_gears/10_fuses/qet_directory
+++ b/10_electric/11_singlepole/200_fuses_protective_gears/10_fuses/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="F">
     <names>
         <name lang="ar">حوامل-مصهرات</name>
         <name lang="cs">Pojistky</name>

--- a/10_electric/11_singlepole/200_fuses_protective_gears/11_circuit_breakers/qet_directory
+++ b/10_electric/11_singlepole/200_fuses_protective_gears/11_circuit_breakers/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="Q">
     <names>
         <name lang="ar">قواطع</name>
         <name lang="cs">Jističe</name>

--- a/10_electric/11_singlepole/200_fuses_protective_gears/12_magneto_thermal_circuit_breakers/qet_directory
+++ b/10_electric/11_singlepole/200_fuses_protective_gears/12_magneto_thermal_circuit_breakers/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="Q">
     <names>
         <name lang="ar">GV قواطع مغناطسية-حرارية</name>
         <name lang="cs">Magnetotepelný jistič GV</name>

--- a/10_electric/11_singlepole/200_fuses_protective_gears/20_disconnecting_switches/qet_directory
+++ b/10_electric/11_singlepole/200_fuses_protective_gears/20_disconnecting_switches/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="ar">عازلات</name>
         <name lang="cs">Odpojovače</name>

--- a/10_electric/11_singlepole/200_fuses_protective_gears/30_thermal_relays/qet_directory
+++ b/10_electric/11_singlepole/200_fuses_protective_gears/30_thermal_relays/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="F">
     <names>
         <name lang="ar">مُرحلات حرارية</name>
         <name lang="cs">Tepelná relé</name>

--- a/10_electric/11_singlepole/200_fuses_protective_gears/50_residual_current_circuit_breaker/qet_directory
+++ b/10_electric/11_singlepole/200_fuses_protective_gears/50_residual_current_circuit_breaker/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="ar">قواطع تفاضلية</name>
         <name lang="cs">Proudové chrániče</name>

--- a/10_electric/11_singlepole/330_transformers_power_supplies/10_transformers/qet_directory
+++ b/10_electric/11_singlepole/330_transformers_power_supplies/10_transformers/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="T">
     <names>
         <name lang="ar">مُحوّلات</name>
         <name lang="cs">Transformátory</name>

--- a/10_electric/11_singlepole/330_transformers_power_supplies/20_current_tansformers/qet_directory
+++ b/10_electric/11_singlepole/330_transformers_power_supplies/20_current_tansformers/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="T">
     <names>
         <name lang="cs">Transformátory proudu</name>
         <name lang="de">Stromwandler</name>

--- a/10_electric/11_singlepole/340_converters_inverters/10_converters/qet_directory
+++ b/10_electric/11_singlepole/340_converters_inverters/10_converters/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="R">
     <names>
         <name lang="ar">مُحوّلات الكترونيات القدرة</name>
         <name lang="cs">Měniče</name>

--- a/10_electric/11_singlepole/392_generators_sources/10_generators/qet_directory
+++ b/10_electric/11_singlepole/392_generators_sources/10_generators/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="G">
     <names>
         <name lang="cs">Generátory</name>
         <name lang="de">Generatoren</name>

--- a/10_electric/11_singlepole/395_electronics_semiconductors/10_resistors/qet_directory
+++ b/10_electric/11_singlepole/395_electronics_semiconductors/10_resistors/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="R">
     <names>
         <name lang="ar">مُقاومة</name>
         <name lang="cs">Rezistory</name>

--- a/10_electric/11_singlepole/395_electronics_semiconductors/20_capacitors/qet_directory
+++ b/10_electric/11_singlepole/395_electronics_semiconductors/20_capacitors/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="C">
     <names>
         <name lang="ar">مُكثّف</name>
         <name lang="cs">Kondenzátor</name>

--- a/10_electric/11_singlepole/395_electronics_semiconductors/30_inductors/qet_directory
+++ b/10_electric/11_singlepole/395_electronics_semiconductors/30_inductors/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="R">
     <names>
         <name lang="cs">Cívky</name>
         <name lang="de">Induktivitäten</name>

--- a/10_electric/11_singlepole/500_home_installation/20_home_appliances/qet_directory
+++ b/10_electric/11_singlepole/500_home_installation/20_home_appliances/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="ar">أجهزة</name>
         <name lang="cs">Spotřebiče</name>

--- a/10_electric/11_singlepole/500_home_installation/25_V.D.I/Terrestrial_reception/antennas/qet_directory
+++ b/10_electric/11_singlepole/500_home_installation/25_V.D.I/Terrestrial_reception/antennas/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="cs">Antény</name>
         <name lang="de">Antennen</name>

--- a/10_electric/11_singlepole/500_home_installation/25_V.D.I/Terrestrial_reception/cables/qet_directory
+++ b/10_electric/11_singlepole/500_home_installation/25_V.D.I/Terrestrial_reception/cables/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="W">
     <names>
         <name lang="cs">Kabely</name>
         <name lang="de">Kabel</name>

--- a/10_electric/11_singlepole/500_home_installation/25_V.D.I/Terrestrial_reception/connectors_plugs/qet_directory
+++ b/10_electric/11_singlepole/500_home_installation/25_V.D.I/Terrestrial_reception/connectors_plugs/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Konektory a zásuvky</name>
         <name lang="de">Stecker / Verbinder</name>

--- a/10_electric/11_singlepole/500_home_installation/25_V.D.I/Terrestrial_reception/qet_directory
+++ b/10_electric/11_singlepole/500_home_installation/25_V.D.I/Terrestrial_reception/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="G">
     <names>
         <name lang="cs">Pozemní příjem</name>
         <name lang="de">Terrestrischer Empfang</name>

--- a/10_electric/11_singlepole/500_home_installation/25_V.D.I/Terrestrial_reception/sockets/qet_directory
+++ b/10_electric/11_singlepole/500_home_installation/25_V.D.I/Terrestrial_reception/sockets/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">FM zásuvky</name>
         <name lang="de">Antennensteckdosen</name>

--- a/10_electric/11_singlepole/500_home_installation/25_V.D.I/network/brassage/qet_directory
+++ b/10_electric/11_singlepole/500_home_installation/25_V.D.I/network/brassage/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="cs">Síťové přepínače</name>
         <name lang="de">Netzwerk (Patch-Panel, Switche, …)</name>

--- a/10_electric/11_singlepole/500_home_installation/25_V.D.I/network/cables_brassage/qet_directory
+++ b/10_electric/11_singlepole/500_home_installation/25_V.D.I/network/cables_brassage/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Propojovací kabely</name>
         <name lang="de">Patch-Kabel</name>

--- a/10_electric/11_singlepole/500_home_installation/25_V.D.I/network/cables_reseau/qet_directory
+++ b/10_electric/11_singlepole/500_home_installation/25_V.D.I/network/cables_reseau/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="W">
     <names>
         <name lang="cs">Síťové kabely</name>
         <name lang="de">Netzwerk-Kabel</name>

--- a/10_electric/11_singlepole/500_home_installation/25_V.D.I/network/prises_reseau/qet_directory
+++ b/10_electric/11_singlepole/500_home_installation/25_V.D.I/network/prises_reseau/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Síťové zásuvky</name>
         <name lang="de">Netzwerk-Anschlüsse</name>

--- a/10_electric/11_singlepole/500_home_installation/30_architectural/qet_directory
+++ b/10_electric/11_singlepole/500_home_installation/30_architectural/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="ar">هندسية</name>
         <name lang="cs">Architektura</name>

--- a/10_electric/11_singlepole/500_home_installation/40_meters/qet_directory
+++ b/10_electric/11_singlepole/500_home_installation/40_meters/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="P">
     <names>
         <name lang="ar">عدّادات</name>
         <name lang="cs">Měřidla</name>

--- a/10_electric/20_manufacturers_articles/abb/20_frequency_drives/qet_directory
+++ b/10_electric/20_manufacturers_articles/abb/20_frequency_drives/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="T">
     <names>
         <name lang="ar">مُغيّرات تردّد</name>
         <name lang="cs">Frekvenční měniče a softstartéry</name>

--- a/10_electric/20_manufacturers_articles/abb/30_softstarters/qet_directory
+++ b/10_electric/20_manufacturers_articles/abb/30_softstarters/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="Q">
     <names>
         <name lang="ar">بادئات حركة تدريجية</name>
         <name lang="cs">Softstartéry</name>

--- a/10_electric/20_manufacturers_articles/allen_bradley/01_PLC_controllers/qet_directory
+++ b/10_electric/20_manufacturers_articles/allen_bradley/01_PLC_controllers/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">PLC a karty</name>
         <name lang="de">SPS und Steuerungen</name>

--- a/10_electric/20_manufacturers_articles/allen_bradley/09_safety_modules/qet_directory
+++ b/10_electric/20_manufacturers_articles/allen_bradley/09_safety_modules/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="ar">وحدات السلامة</name>
         <name lang="cs">Bezpečnostní moduly</name>

--- a/10_electric/20_manufacturers_articles/allen_bradley/11_safety_switches/qet_directory
+++ b/10_electric/20_manufacturers_articles/allen_bradley/11_safety_switches/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="cs">Bezpečnostní spínače</name>
         <name lang="de">Sicherheitsschalter</name>

--- a/10_electric/20_manufacturers_articles/allen_bradley/20_frequency_drives/qet_directory
+++ b/10_electric/20_manufacturers_articles/allen_bradley/20_frequency_drives/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="T">
     <names>
         <name lang="ar">مُغيّرات تردّد</name>
         <name lang="cs">Frekvenční měniče</name>

--- a/10_electric/20_manufacturers_articles/allen_bradley/qet_directory
+++ b/10_electric/20_manufacturers_articles/allen_bradley/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="cs">Allen Bradley</name>
         <name lang="de">Allen Bradley</name>

--- a/10_electric/20_manufacturers_articles/arduino/qet_directory
+++ b/10_electric/20_manufacturers_articles/arduino/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="cs">Arduino</name>
         <name lang="de">Arduino</name>

--- a/10_electric/20_manufacturers_articles/aucom/10_softstarter/qet_directory
+++ b/10_electric/20_manufacturers_articles/aucom/10_softstarter/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="Q">
     <names>
         <name lang="ar">بادئات حركة تدريجية</name>
         <name lang="cs">Softstartéry</name>

--- a/10_electric/20_manufacturers_articles/balluff/04_sensors_optical/qet_directory
+++ b/10_electric/20_manufacturers_articles/balluff/04_sensors_optical/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="ar">حسّاسات بصرية</name>
         <name lang="cs">Optická čidla</name>

--- a/10_electric/20_manufacturers_articles/balluff/51_transformers_power_supply/qet_directory
+++ b/10_electric/20_manufacturers_articles/balluff/51_transformers_power_supply/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="G">
     <names>
         <name lang="cs">Trasformátory a napájecí zdroje</name>
         <name lang="de">Transformatoren und Versorgungen</name>

--- a/10_electric/20_manufacturers_articles/bamo/qet_directory
+++ b/10_electric/20_manufacturers_articles/bamo/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Bamo</name>
         <name lang="de">BAMO IER</name>

--- a/10_electric/20_manufacturers_articles/beckhoff/01_schematic/bus_terminals/qet_directory
+++ b/10_electric/20_manufacturers_articles/beckhoff/01_schematic/bus_terminals/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Sběrnicové terminály</name>
         <name lang="de">Busklemmen</name>

--- a/10_electric/20_manufacturers_articles/beckhoff/01_schematic/ethercat_boxes/qet_directory
+++ b/10_electric/20_manufacturers_articles/beckhoff/01_schematic/ethercat_boxes/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">EtherCAT Boxes</name>
         <name lang="de">EtherCAT Boxen</name>

--- a/10_electric/20_manufacturers_articles/beckhoff/01_schematic/ethercat_terminals/qet_directory
+++ b/10_electric/20_manufacturers_articles/beckhoff/01_schematic/ethercat_terminals/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Terminály EtherCAT</name>
         <name lang="de">EtherCAT-Klemmen</name>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/bus_terminals/qet_directory
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/bus_terminals/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Sběrnicové terminály</name>
         <name lang="de">Busklemmen</name>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_boxes/qet_directory
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_boxes/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">EtherCAT Box</name>
         <name lang="de">EtherCAT Box</name>

--- a/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_terminals/qet_directory
+++ b/10_electric/20_manufacturers_articles/beckhoff/02_front/ethercat_terminals/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Terminály EtherCAT</name>
         <name lang="de">EtherCAT-Klemmen</name>

--- a/10_electric/20_manufacturers_articles/best/qet_directory
+++ b/10_electric/20_manufacturers_articles/best/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="E">
     <names>
         <name lang="cs">Best</name>
         <name lang="fr">Best</name>

--- a/10_electric/20_manufacturers_articles/bosch_rexroth/qet_directory
+++ b/10_electric/20_manufacturers_articles/bosch_rexroth/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="M">
     <names>
         <name lang="cs">Bosch Rexroth</name>
         <name lang="de">Bosch Rexroth</name>

--- a/10_electric/20_manufacturers_articles/bti/11_safety_switches/qet_directory
+++ b/10_electric/20_manufacturers_articles/bti/11_safety_switches/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="cs">Bezpečnostní spínače</name>
         <name lang="de">Sicherheitsschalter</name>

--- a/10_electric/20_manufacturers_articles/bwo/10_vio64/qet_directory
+++ b/10_electric/20_manufacturers_articles/bwo/10_vio64/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">VIO 64</name>
         <name lang="en">VIO 64</name>

--- a/10_electric/20_manufacturers_articles/campbell/qet_directory
+++ b/10_electric/20_manufacturers_articles/campbell/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="G">
     <names>
         <name lang="cs">Campbell</name>
         <name lang="de">Campbell</name>

--- a/10_electric/20_manufacturers_articles/chisage/qet_directory
+++ b/10_electric/20_manufacturers_articles/chisage/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="T">
     <names>
         <name lang="de">CHISAGE ESS</name>
         <name lang="en">CHISAGE ESS</name>

--- a/10_electric/20_manufacturers_articles/circuit-microsens/qet_directory
+++ b/10_electric/20_manufacturers_articles/circuit-microsens/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="E">
     <names>
         <name lang="cs">Microsens</name>
         <name lang="de">Microsens</name>

--- a/10_electric/20_manufacturers_articles/citec/06_sensors_pressure/qet_directory
+++ b/10_electric/20_manufacturers_articles/citec/06_sensors_pressure/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="cs">Snímače tlaku</name>
         <name lang="de">Sensoren Druck</name>

--- a/10_electric/20_manufacturers_articles/comitronic/qet_directory
+++ b/10_electric/20_manufacturers_articles/comitronic/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="cs">Comitronic</name>
         <name lang="de">Comitronic - BTI</name>

--- a/10_electric/20_manufacturers_articles/crouzet/01_PLC_controllers/qet_directory
+++ b/10_electric/20_manufacturers_articles/crouzet/01_PLC_controllers/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">PLC a karty</name>
         <name lang="de">SPS und Steuerungen</name>

--- a/10_electric/20_manufacturers_articles/cynergy3/qet_directory
+++ b/10_electric/20_manufacturers_articles/cynergy3/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="cs">Cynergy 3</name>
         <name lang="de">Cynergy 3</name>

--- a/10_electric/20_manufacturers_articles/danfoss/10_softstarter/qet_directory
+++ b/10_electric/20_manufacturers_articles/danfoss/10_softstarter/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="Q">
     <names>
         <name lang="ar">بادئات حركة تدريجية</name>
         <name lang="cs">Softstartéry</name>

--- a/10_electric/20_manufacturers_articles/danfoss/20_frequency_drives/qet_directory
+++ b/10_electric/20_manufacturers_articles/danfoss/20_frequency_drives/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="T">
     <names>
         <name lang="ar">مُغيّرات تردّد</name>
         <name lang="cs">Frekvenční měniče</name>

--- a/10_electric/20_manufacturers_articles/danfoss/qet_directory
+++ b/10_electric/20_manufacturers_articles/danfoss/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="P">
     <names>
         <name lang="cs">Danfoss</name>
         <name lang="de">Danfoss</name>

--- a/10_electric/20_manufacturers_articles/delta/frequency_drives/qet_directory
+++ b/10_electric/20_manufacturers_articles/delta/frequency_drives/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="T">
     <names>
         <name lang="ar">مُغيّرات تردّد</name>
         <name lang="cs">Frekvenční měniče</name>

--- a/10_electric/20_manufacturers_articles/delta/plc_and_controllers/as-series/qet_directory
+++ b/10_electric/20_manufacturers_articles/delta/plc_and_controllers/as-series/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="en">As_series</name>
         <name lang="pt_BR">CLPs Delta - Série AS</name>

--- a/10_electric/20_manufacturers_articles/delta/plc_and_controllers/dvp12se11r/qet_directory
+++ b/10_electric/20_manufacturers_articles/delta/plc_and_controllers/dvp12se11r/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">DVP12SE11R</name>
         <name lang="de">DVP12SE11R</name>

--- a/10_electric/20_manufacturers_articles/delta/plc_and_controllers/dvp12ss211s/qet_directory
+++ b/10_electric/20_manufacturers_articles/delta/plc_and_controllers/dvp12ss211s/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">DVP12SS211S</name>
         <name lang="de">DVP12SS211S</name>

--- a/10_electric/20_manufacturers_articles/delta/plc_and_controllers/dvp14ss211r/qet_directory
+++ b/10_electric/20_manufacturers_articles/delta/plc_and_controllers/dvp14ss211r/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">DVP14SS211R</name>
         <name lang="de">DVP14SS211R</name>

--- a/10_electric/20_manufacturers_articles/delta/plc_and_controllers/dvp14ss211t/qet_directory
+++ b/10_electric/20_manufacturers_articles/delta/plc_and_controllers/dvp14ss211t/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">DVP14SS211T</name>
         <name lang="de">DVP14SS211T</name>

--- a/10_electric/20_manufacturers_articles/delta/plc_and_controllers/qet_directory
+++ b/10_electric/20_manufacturers_articles/delta/plc_and_controllers/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">PLC a řízení</name>
         <name lang="de">SPS und Steuerungen</name>

--- a/10_electric/20_manufacturers_articles/eaton_moeller/01_PLC_controllers/qet_directory
+++ b/10_electric/20_manufacturers_articles/eaton_moeller/01_PLC_controllers/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">PLC a karty</name>
         <name lang="de">SPS und Steuerungen</name>

--- a/10_electric/20_manufacturers_articles/eliwel/qet_directory
+++ b/10_electric/20_manufacturers_articles/eliwel/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Eliwell</name>
         <name lang="de">Eliwell</name>

--- a/10_electric/20_manufacturers_articles/endress_hauser/qet_directory
+++ b/10_electric/20_manufacturers_articles/endress_hauser/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="cs">Endress+Hauser</name>
         <name lang="de">Endress+Hauser</name>

--- a/10_electric/20_manufacturers_articles/euchner/11_safety_switches/qet_directory
+++ b/10_electric/20_manufacturers_articles/euchner/11_safety_switches/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="cs">Bezpečnostní zámek</name>
         <name lang="de">Sicherheitsschalter</name>

--- a/10_electric/20_manufacturers_articles/eurotherm/10_softstarters/qet_directory
+++ b/10_electric/20_manufacturers_articles/eurotherm/10_softstarters/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="Q">
     <names>
         <name lang="ar">بادئات حركة تدريجية</name>
         <name lang="cs">Softstartéry</name>

--- a/10_electric/20_manufacturers_articles/ewon/qet_directory
+++ b/10_electric/20_manufacturers_articles/ewon/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="ar">ewon router</name>
         <name lang="ca">ewon router</name>

--- a/10_electric/20_manufacturers_articles/festo/qet_directory
+++ b/10_electric/20_manufacturers_articles/festo/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="H">
     <names>
         <name lang="cs">Festo</name>
         <name lang="de">Festo</name>

--- a/10_electric/20_manufacturers_articles/fibaro/qet_directory
+++ b/10_electric/20_manufacturers_articles/fibaro/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="cs">Fibaro</name>
         <name lang="de">Fibaro</name>

--- a/10_electric/20_manufacturers_articles/fuji_electric/20_frequency_drives/qet_directory
+++ b/10_electric/20_manufacturers_articles/fuji_electric/20_frequency_drives/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="T">
     <names>
         <name lang="ar">مُغيّرات تردّد</name>
         <name lang="cs">Frekvenční měniče</name>

--- a/10_electric/20_manufacturers_articles/gce/qet_directory
+++ b/10_electric/20_manufacturers_articles/gce/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="P">
     <names>
         <name lang="cs">GCE Electronics</name>
         <name lang="de">GCE Electronics</name>

--- a/10_electric/20_manufacturers_articles/geindustrial/10_sofstarters/qet_directory
+++ b/10_electric/20_manufacturers_articles/geindustrial/10_sofstarters/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="Q">
     <names>
         <name lang="ar">بادئات حركة تدريجية</name>
         <name lang="cs">Softstartéry</name>

--- a/10_electric/20_manufacturers_articles/grove/qet_directory
+++ b/10_electric/20_manufacturers_articles/grove/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="fr">grove</name>
         <name lang="en">grove</name>

--- a/10_electric/20_manufacturers_articles/guitar/capacitors/qet_directory
+++ b/10_electric/20_manufacturers_articles/guitar/capacitors/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="C">
     <names>
         <name lang="cs">Rezistory a kondenzátory</name>
         <name lang="en">Capacitors and Resistors</name>

--- a/10_electric/20_manufacturers_articles/guitar/ouputjacks/qet_directory
+++ b/10_electric/20_manufacturers_articles/guitar/ouputjacks/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Konektory Jack</name>
         <name lang="en">Output Jacks</name>

--- a/10_electric/20_manufacturers_articles/guitar/pickups/qet_directory
+++ b/10_electric/20_manufacturers_articles/guitar/pickups/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Kytarové snímače</name>
         <name lang="en">Pickups</name>

--- a/10_electric/20_manufacturers_articles/guitar/switches/qet_directory
+++ b/10_electric/20_manufacturers_articles/guitar/switches/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="cs">Spínače a voliče</name>
         <name lang="en">Switches and Selectors</name>

--- a/10_electric/20_manufacturers_articles/idec/qet_directory
+++ b/10_electric/20_manufacturers_articles/idec/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="cs">IDEC</name>
         <name lang="de">IDEC</name>

--- a/10_electric/20_manufacturers_articles/ifm/06_sensors_pressure/qet_directory
+++ b/10_electric/20_manufacturers_articles/ifm/06_sensors_pressure/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="cs">Snímače tlaku</name>
         <name lang="de">Druck-Sensoren</name>

--- a/10_electric/20_manufacturers_articles/ifm/qet_directory
+++ b/10_electric/20_manufacturers_articles/ifm/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="E">
     <names>
         <name lang="cs">IFM</name>
         <name lang="de">ifm</name>

--- a/10_electric/20_manufacturers_articles/johnson_controls/dx/modules_extension/qet_directory
+++ b/10_electric/20_manufacturers_articles/johnson_controls/dx/modules_extension/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Rozšiřující moduly</name>
         <name lang="de">Erweiterungsmodule</name>

--- a/10_electric/20_manufacturers_articles/johnson_controls/dx/qet_directory
+++ b/10_electric/20_manufacturers_articles/johnson_controls/dx/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Řada DX</name>
         <name lang="de">DX Baureihe</name>

--- a/10_electric/20_manufacturers_articles/johnson_controls/qet_directory
+++ b/10_electric/20_manufacturers_articles/johnson_controls/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="cs">Johnson Controls</name>
         <name lang="de">Johnson Controls</name>

--- a/10_electric/20_manufacturers_articles/kamstrup/qet_directory
+++ b/10_electric/20_manufacturers_articles/kamstrup/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="ca">Kamstrup</name>
         <name lang="cs">Kamstrup</name>

--- a/10_electric/20_manufacturers_articles/knx/actionneur/qet_directory
+++ b/10_electric/20_manufacturers_articles/knx/actionneur/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="M">
     <names>
         <name lang="cs">Ovladač</name>
         <name lang="de">Aktoren</name>

--- a/10_electric/20_manufacturers_articles/knx/capteurs/qet_directory
+++ b/10_electric/20_manufacturers_articles/knx/capteurs/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="ar">حساسات</name>
         <name lang="cs">Čidla</name>

--- a/10_electric/20_manufacturers_articles/knx/divers/qet_directory
+++ b/10_electric/20_manufacturers_articles/knx/divers/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="G">
     <names>
         <name lang="ar">متفرقات</name>
         <name lang="cs">Různé</name>

--- a/10_electric/20_manufacturers_articles/knx/poussoirs/qet_directory
+++ b/10_electric/20_manufacturers_articles/knx/poussoirs/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="cs">Tlačítka</name>
         <name lang="de">Drucktaster</name>

--- a/10_electric/20_manufacturers_articles/knx/powersupplies/qet_directory
+++ b/10_electric/20_manufacturers_articles/knx/powersupplies/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="G">
     <names>
         <name lang="cs">Napájecí zdroje</name>
         <name lang="de">Versorgungen</name>

--- a/10_electric/20_manufacturers_articles/knx/qet_directory
+++ b/10_electric/20_manufacturers_articles/knx/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="T">
     <names>
         <name lang="cs">KNX</name>
         <name lang="de">KNX</name>

--- a/10_electric/20_manufacturers_articles/leadshine/servo_driver/qet_directory
+++ b/10_electric/20_manufacturers_articles/leadshine/servo_driver/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="M">
     <names>
         <name lang="de">AC Servo System</name>
         <name lang="fr">Contrôleur Servo AC</name>

--- a/10_electric/20_manufacturers_articles/lemo/qet_directory
+++ b/10_electric/20_manufacturers_articles/lemo/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Lemo</name>
         <name lang="da">Lemo</name>

--- a/10_electric/20_manufacturers_articles/lenze/qet_directory
+++ b/10_electric/20_manufacturers_articles/lenze/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="T">
     <names>
         <name lang="cs">Lenze</name>
         <name lang="de">Lenze</name>

--- a/10_electric/20_manufacturers_articles/leroy_somer/20_frequency_drives/qet_directory
+++ b/10_electric/20_manufacturers_articles/leroy_somer/20_frequency_drives/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="T">
     <names>
         <name lang="ar">مُغيّرات تردّد</name>
         <name lang="cs">Frekvenční měniče</name>

--- a/10_electric/20_manufacturers_articles/loxone/loxone_miniserver_gen_1/qet_directory
+++ b/10_electric/20_manufacturers_articles/loxone/loxone_miniserver_gen_1/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="de">Loxone Miniserver Gen.1</name>
         <name lang="ko">Loxone 미니서버 1세대</name>

--- a/10_electric/20_manufacturers_articles/loxone/loxone_relay_extension/qet_directory
+++ b/10_electric/20_manufacturers_articles/loxone/loxone_relay_extension/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="de">Loxone Relay Extension-</name>
         <name lang="ko">Loxone 릴레이 확장</name>

--- a/10_electric/20_manufacturers_articles/loxone/qet_directory
+++ b/10_electric/20_manufacturers_articles/loxone/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="W">
     <names>
         <name lang="de">Loxone</name>
         <name lang="ko">Loxone</name>

--- a/10_electric/20_manufacturers_articles/mayr/qet_directory
+++ b/10_electric/20_manufacturers_articles/mayr/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="cs">Mayr</name>
         <name lang="de">Mayr</name>

--- a/10_electric/20_manufacturers_articles/mdt/bereichs-_linienkoppler/grafik/zeitschaltuhr/qet_directory
+++ b/10_electric/20_manufacturers_articles/mdt/bereichs-_linienkoppler/grafik/zeitschaltuhr/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="de">Zeitschaltuhr</name>
         <name lang="en">Timer</name>

--- a/10_electric/20_manufacturers_articles/mdt/schaltaktoren/grafik/azi_mit_wirkleistungszaehler/qet_directory
+++ b/10_electric/20_manufacturers_articles/mdt/schaltaktoren/grafik/azi_mit_wirkleistungszaehler/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="P">
     <names>
         <name lang="de">AZI (Wirkleistungszähler)</name>
         <name lang="en">AZI (active power meter)</name>

--- a/10_electric/20_manufacturers_articles/murr_elektronik/370_fuses_protective_gears/qet_directory
+++ b/10_electric/20_manufacturers_articles/murr_elektronik/370_fuses_protective_gears/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="F">
     <names>
         <name lang="cs">Pojistky a ochrany</name>
         <name lang="de">Sicherungen und Schutzeinrichtungen</name>

--- a/10_electric/20_manufacturers_articles/national_instrument/01_PLC_controllers/crio/qet_directory
+++ b/10_electric/20_manufacturers_articles/national_instrument/01_PLC_controllers/crio/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="ar">cRIO</name>
         <name lang="cs">cRIO</name>

--- a/10_electric/20_manufacturers_articles/network/qet_directory
+++ b/10_electric/20_manufacturers_articles/network/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Síť</name>
         <name lang="en">Network</name>

--- a/10_electric/20_manufacturers_articles/omron/01_PLC_controllers/cj1/taille1/qet_directory
+++ b/10_electric/20_manufacturers_articles/omron/01_PLC_controllers/cj1/taille1/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="ar">حجم 1</name>
         <name lang="cs">Velikost 1</name>

--- a/10_electric/20_manufacturers_articles/omron/01_PLC_controllers/cj1/taille2/qet_directory
+++ b/10_electric/20_manufacturers_articles/omron/01_PLC_controllers/cj1/taille2/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="ar">حجم 2</name>
         <name lang="cs">Velikost 2</name>

--- a/10_electric/20_manufacturers_articles/omron/01_PLC_controllers/cj2/qet_directory
+++ b/10_electric/20_manufacturers_articles/omron/01_PLC_controllers/cj2/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="ar">Cj2</name>
         <name lang="cs">Cj2</name>

--- a/10_electric/20_manufacturers_articles/omron/01_PLC_controllers/cqm1/taille1/qet_directory
+++ b/10_electric/20_manufacturers_articles/omron/01_PLC_controllers/cqm1/taille1/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="ar">حجم 1</name>
         <name lang="cs">Velikost 1</name>

--- a/10_electric/20_manufacturers_articles/omron/01_PLC_controllers/cqm1/taille2/qet_directory
+++ b/10_electric/20_manufacturers_articles/omron/01_PLC_controllers/cqm1/taille2/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="ar">حجم 2</name>
         <name lang="cs">Velikost 2</name>

--- a/10_electric/20_manufacturers_articles/omron/01_PLC_controllers/qet_directory
+++ b/10_electric/20_manufacturers_articles/omron/01_PLC_controllers/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">PLC a kontroléry</name>
         <name lang="de">SPS und Steuerungen</name>

--- a/10_electric/20_manufacturers_articles/omron/03_relays/qet_directory
+++ b/10_electric/20_manufacturers_articles/omron/03_relays/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Relé</name>
         <name lang="de">Relais</name>

--- a/10_electric/20_manufacturers_articles/omron/20_frequency_drives/qet_directory
+++ b/10_electric/20_manufacturers_articles/omron/20_frequency_drives/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="T">
     <names>
         <name lang="ar">مُغيّرات تردّد</name>
         <name lang="cs">Frekvenční měniče</name>

--- a/10_electric/20_manufacturers_articles/onn-m4t/qet_directory
+++ b/10_electric/20_manufacturers_articles/onn-m4t/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="E">
     <names>
         <name lang="cs">ONNM4T</name>
         <name lang="de">ONNM4T</name>

--- a/10_electric/20_manufacturers_articles/perske/qet_directory
+++ b/10_electric/20_manufacturers_articles/perske/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="M">
     <names>
         <name lang="cs">Perske</name>
         <name lang="de">Perske</name>

--- a/10_electric/20_manufacturers_articles/phoenix_contact/qet_directory
+++ b/10_electric/20_manufacturers_articles/phoenix_contact/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="T">
     <names>
         <name lang="cs">Phoenix Contact</name>
         <name lang="de">Phoenix Contact</name>

--- a/10_electric/20_manufacturers_articles/pilz/15_safety_switches/psen/qet_directory
+++ b/10_electric/20_manufacturers_articles/pilz/15_safety_switches/psen/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="C">Psen</name>
         <name lang="ar">Psen</name>

--- a/10_electric/20_manufacturers_articles/pinball/williams_em/jacks/qet_directory
+++ b/10_electric/20_manufacturers_articles/pinball/williams_em/jacks/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="en">Jacks</name>
         <name lang="nl">Contacten</name>

--- a/10_electric/20_manufacturers_articles/pinball/williams_em/output/qet_directory
+++ b/10_electric/20_manufacturers_articles/pinball/williams_em/output/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="en">Output</name>
         <name lang="nl">Uitvoer</name>

--- a/10_electric/20_manufacturers_articles/pinball/williams_em/power/qet_directory
+++ b/10_electric/20_manufacturers_articles/pinball/williams_em/power/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="F">
     <names>
         <name lang="en">Power</name>
         <name lang="nl">Stroom</name>

--- a/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/mirrored/qet_directory
+++ b/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/mirrored/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="en">Mirrored</name>
         <name lang="nl">Gespiegeld</name>

--- a/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/qet_directory
+++ b/10_electric/20_manufacturers_articles/pinball/williams_em/switches_common/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="en">Switches - Common</name>
         <name lang="nl">Schakelaars - Algemeen</name>

--- a/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/mirrored/qet_directory
+++ b/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/mirrored/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="M">
     <names>
         <name lang="en">Mirrored</name>
         <name lang="nl">Gespiegeld</name>

--- a/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/qet_directory
+++ b/10_electric/20_manufacturers_articles/pinball/williams_em/switches_score_motor/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="M">
     <names>
         <name lang="en">Switches - Score Motor</name>
         <name lang="nl">Schakelaars - Score Motor</name>

--- a/10_electric/20_manufacturers_articles/qubino/qet_directory
+++ b/10_electric/20_manufacturers_articles/qubino/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="ca">Qubino</name>
         <name lang="cs">Qubino</name>

--- a/10_electric/20_manufacturers_articles/rexroth/qet_directory
+++ b/10_electric/20_manufacturers_articles/rexroth/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="cs">Rexroth</name>
         <name lang="de">Rexroth</name>

--- a/10_electric/20_manufacturers_articles/rittal/qet_directory
+++ b/10_electric/20_manufacturers_articles/rittal/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="cs">Rittal</name>
         <name lang="de">Rittal</name>

--- a/10_electric/20_manufacturers_articles/rockwell/10_softstarters/qet_directory
+++ b/10_electric/20_manufacturers_articles/rockwell/10_softstarters/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="Q">
     <names>
         <name lang="ar">بادئات حركة تدريجية</name>
         <name lang="cs">Softstartéry</name>

--- a/10_electric/20_manufacturers_articles/rockwell/qet_directory
+++ b/10_electric/20_manufacturers_articles/rockwell/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Rockwell</name>
         <name lang="de">Rockwell</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/advantys-stb/analog-block/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/advantys-stb/analog-block/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Analogové karty</name>
         <name lang="en">Analog-block</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/advantys-stb/controller-block/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/advantys-stb/controller-block/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Karty kontrolérů</name>
         <name lang="en">Controller-block</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/advantys-stb/discrete-block/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/advantys-stb/discrete-block/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Karty DI a DO</name>
         <name lang="en">Digital-block</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/advantys-stb/supply-block/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/advantys-stb/supply-block/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Napájecí zdroj</name>
         <name lang="en">Supply-block</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/extension-tm4/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/extension-tm4/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Rozšiřující moduly TM4</name>
         <name lang="en">Extension TM4</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/extension_tm3/ana/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/extension_tm3/ana/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Karty analogových vstupů/výstupů</name>
         <name lang="de">Analoge Ein- und Ausgangskarten</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/extension_tm3/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/extension_tm3/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Rozšiřující moduly TM3</name>
         <name lang="en">Extension TM3</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/extension_tm3/tor/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/extension_tm3/tor/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Karty vstupů a výstupů</name>
         <name lang="en">Input Output cards</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/hmiet6400/frontview/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/hmiet6400/frontview/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="en">frontview</name>
         <name lang="ko">전면도</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/hmiet6400/hindview/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/hmiet6400/hindview/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="en">hindview</name>
         <name lang="ko">후면도</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/m221/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/m221/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">M221</name>
         <name lang="en">M221</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/m241/tm241ce24r/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/m241/tm241ce24r/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">TM241CE24R</name>
         <name lang="fr">TM241CE24R</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/m241/tm241ce24t/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/m241/tm241ce24t/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">TM241CE24T</name>
         <name lang="fr">TM241CE24T</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/m251/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/m251/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">M251</name>
         <name lang="en">M251</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/m340/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/m340/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">M340</name>
         <name lang="en">M340</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/magelis/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/magelis/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Magelis</name>
         <name lang="en">Magelis</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/modicon-m340/analog-block/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/modicon-m340/analog-block/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Analoggové karty</name>
         <name lang="en">Analog block</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/modicon-m340/analog-connector/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/modicon-m340/analog-connector/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Analogové vstupy</name>
         <name lang="en">Analog connector</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/modicon-m340/communication-block/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/modicon-m340/communication-block/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Komunikační karty</name>
         <name lang="en">Communication block</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/modicon-m340/controller-block/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/modicon-m340/controller-block/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Karty CPU</name>
         <name lang="en">Controller block</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/modicon-m340/counting/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/modicon-m340/counting/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Karty rychlých čítačů</name>
         <name lang="en">Counting</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/modicon-m340/discret-connector/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/modicon-m340/discret-connector/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Karty digitálních vstupů a výstupů</name>
         <name lang="en">Discret connector</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/modicon-m340/discrete-block/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/modicon-m340/discrete-block/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Karty DI/DO náhledy</name>
         <name lang="en">Digital block</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/modicon-m340/motion-block/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/modicon-m340/motion-block/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Karta PTO 2 kanály</name>
         <name lang="en">Motion block</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/modicon-m340/supply-block/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/modicon-m340/supply-block/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Karty napájení</name>
         <name lang="en">Supply block</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/modicon-m340/third-party-products-block/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/modicon-m340/third-party-products-block/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Karty jiných výrobců</name>
         <name lang="en">Third party products bloc</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/modicon-m340/tsxtlyex-line-terminator-for-bmxxbe1000/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/modicon-m340/tsxtlyex-line-terminator-for-bmxxbe1000/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Linkový terminátor</name>
         <name lang="en">Line-terminator</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">PLC a kontroléry</name>
         <name lang="de">SPS und Steuerungen</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/telefast/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/telefast/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Základny pro analog. karty</name>
         <name lang="de">Telefast Platine</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/tm62/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/tm62/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">TM62</name>
         <name lang="en">TM62</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/tsx/input/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/tsx/input/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Karty vstupů</name>
         <name lang="de">Eingangskarten</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/tsx/output/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/tsx/output/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Karty výstupů</name>
         <name lang="de">Ausgangskarten</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/tsx/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/tsx/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">TSX Konfigurace HW</name>
         <name lang="de">TSX Übersichtzeichnungen</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/twido/e-s_ana/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/twido/e-s_ana/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">I/O ANALOG</name>
         <name lang="en">I/O ANA</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/twido/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/twido/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Twido</name>
         <name lang="de">Twido</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/zelio/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/01_PLC_controllers/zelio/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Zelio</name>
         <name lang="de">Zelio</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/08_control_relays/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/08_control_relays/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="ar">مُرحلات تحكّم</name>
         <name lang="cs">Řídící relé</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/10_softstarter/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/10_softstarter/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="Q">
     <names>
         <name lang="ar">بادئات حركة تدريجية</name>
         <name lang="cs">Softstartéry</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/20_frequency_drives/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/20_frequency_drives/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="T">
     <names>
         <name lang="ar">مُغيّرات تردّد</name>
         <name lang="cs">Frekvenční měniče</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/81_safety_switches/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/81_safety_switches/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="cs">Bezpečnostní spínače</name>
         <name lang="de">Sicherheitsschalter</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/90_TAC_Xenta/boitier_mural/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/90_TAC_Xenta/boitier_mural/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="N">
     <names>
         <name lang="ar">عُلب حائطيّة</name>
         <name lang="cs">Nástěnné moduly</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/90_TAC_Xenta/ecran/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/90_TAC_Xenta/ecran/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="P">
     <names>
         <name lang="ar">شاشة</name>
         <name lang="cs">Obrazovka</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/90_TAC_Xenta/peripheriques/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/90_TAC_Xenta/peripheriques/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="T">
     <names>
         <name lang="ar">طرفيات</name>
         <name lang="cs">Periferie</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/protection/Battery_control_module/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/protection/Battery_control_module/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="G">
     <names>
         <name lang="cs">Kontrolní modul baterie</name>
         <name lang="en">Battery control module</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/protection/Power_supply/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/protection/Power_supply/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="G">
     <names>
         <name lang="cs">Napájecí zdroje</name>
         <name lang="en">Power supply</name>

--- a/10_electric/20_manufacturers_articles/schneider_electric/protection/Three-phase_network_control_relay/qet_directory
+++ b/10_electric/20_manufacturers_articles/schneider_electric/protection/Three-phase_network_control_relay/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Třífázové hlídací relé</name>
         <name lang="en">Three-phase network control relay</name>

--- a/10_electric/20_manufacturers_articles/sew/20_frequency_drives/qet_directory
+++ b/10_electric/20_manufacturers_articles/sew/20_frequency_drives/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="T">
     <names>
         <name lang="ar">مُغيّرات تردّد</name>
         <name lang="cs">Frekvenční měniče</name>

--- a/10_electric/20_manufacturers_articles/sew/qet_directory
+++ b/10_electric/20_manufacturers_articles/sew/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">SEW</name>
         <name lang="de">SEW Eurodrive</name>

--- a/10_electric/20_manufacturers_articles/shelly/qet_directory
+++ b/10_electric/20_manufacturers_articles/shelly/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="de">Shelly</name>
         <name lang="en">Shelly</name>

--- a/10_electric/20_manufacturers_articles/sick/008_safety_controllers/qet_directory
+++ b/10_electric/20_manufacturers_articles/sick/008_safety_controllers/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Bezpečnostní PLC</name>
         <name lang="de">Sicherheitssteuerungen</name>

--- a/10_electric/20_manufacturers_articles/sick/100_safety_light_curtain/qet_directory
+++ b/10_electric/20_manufacturers_articles/sick/100_safety_light_curtain/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="E">
     <names>
         <name lang="ar">حاجز حماية لا مادي</name>
         <name lang="cs">Bezpečnostní světelný závěs</name>

--- a/10_electric/20_manufacturers_articles/sick/101_safety_switches/qet_directory
+++ b/10_electric/20_manufacturers_articles/sick/101_safety_switches/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="cs">Bezpečnostní spínače</name>
         <name lang="de">Sicherheitsschalter</name>

--- a/10_electric/20_manufacturers_articles/sick/qet_directory
+++ b/10_electric/20_manufacturers_articles/sick/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="cs">Sick</name>
         <name lang="de">Sick</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es5/6es5_95/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es5/6es5_95/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Siemens 6ES5_95</name>
         <name lang="de">Siemens 6ES5_95</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es5/carte_entree/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es5/carte_entree/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Karty vstupu</name>
         <name lang="de">Eingangskarten</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es5/carte_sortie/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es5/carte_sortie/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Karty výstupu</name>
         <name lang="de">Ausgangskarten</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es5/cpu/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es5/cpu/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Cpu</name>
         <name lang="de">CPU</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es5/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es5/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">6ES5</name>
         <name lang="de">6ES5</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7-1200/communication_cards/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7-1200/communication_cards/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Komunikační karty</name>
         <name lang="en">communication_cards</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7-1200/digital_inputs-outputs_cards/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7-1200/digital_inputs-outputs_cards/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Vstupní a výstupní karty</name>
         <name lang="en">Input Output cards</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7-1200/digital_inputs_cards/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7-1200/digital_inputs_cards/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Karty vstupů</name>
         <name lang="de">Eingangskarten</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7-1200/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7-1200/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">6ES7-1200</name>
         <name lang="de">6ES7-1200</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7-13/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7-13/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="en">6ES7-13</name>
         <name lang="fr">6ES7-13</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7-1500/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7-1500/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">6ES7-1500</name>
         <name lang="de">6ES7-1500</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7-200/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7-200/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="de">6ES7-200</name>
         <name lang="en">6ES7-200</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7-212/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7-212/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">6ES7-200</name>
         <name lang="de">6ES7-200</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7-312/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7-312/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">6ES7-312</name>
         <name lang="de">6ES7-312</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7-313/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7-313/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">6ES7-313</name>
         <name lang="de">6ES7-313</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7/alimentations/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7/alimentations/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="G">
     <names>
         <name lang="cs">Napájení</name>
         <name lang="de">Netzgeräte</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7/cartes_ana_entree/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7/cartes_ana_entree/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Karty analogových vstupů</name>
         <name lang="de">Analoge Eingangskarten</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7/cartes_ana_entree_sortie/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7/cartes_ana_entree_sortie/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Karty analogových vstupů/výstupů</name>
         <name lang="de">Analoge Ein- und Ausgangskarten</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7/cartes_ana_sortie/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7/cartes_ana_sortie/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Karty analogových výstupů</name>
         <name lang="de">Analoge Ausgangskarten</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7/cartes_entree/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7/cartes_entree/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Karty výstupů</name>
         <name lang="de">Digitale Eingangskarten</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7/cartes_sortie/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6es7/cartes_sortie/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Karty výstupů</name>
         <name lang="de">Ausgangskarten</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6se7-300/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/6se7-300/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">6ES7-300</name>
         <name lang="de">6ES7-300</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/config/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/config/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Konfigurace HW</name>
         <name lang="de">Übersichtzeichnungen</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/cp_343-2/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/cp_343-2/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Komunikační karty</name>
         <name lang="de">Kommunikationsbaugruppen</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/et200s/cards_and_modules/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/et200s/cards_and_modules/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Karty a moduly</name>
         <name lang="de">Karten und Module</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/et200s/channels/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/et200s/channels/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Kanály</name>
         <name lang="de">Kanäle</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/et200s/io_overviews/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/et200s/io_overviews/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">I/O karty</name>
         <name lang="de">E/A-Übersichten</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/et200s/power_supply/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/et200s/power_supply/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Napájecí zdroje</name>
         <name lang="de">Versorgung</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/et200s/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/et200s/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">ET 200S</name>
         <name lang="en">ET 200S</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/interface_modules/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/interface_modules/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Moduly rozhraní</name>
         <name lang="de">Schnittstellenbaugruppen</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/logo/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/logo/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Logo</name>
         <name lang="de">Logo</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">PLC a kontroléry</name>
         <name lang="de">SPS und Steuerungen</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/s7_300/cards_and_modules/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/s7_300/cards_and_modules/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Karty a moduly</name>
         <name lang="de">Karten und Module</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/s7_300/channels/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/s7_300/channels/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="de">Kanäle</name>
         <name lang="en">Channels</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/s7_300/io_overviews/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/s7_300/io_overviews/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="de">E/A-Übersichten</name>
         <name lang="en">I/O overviews</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/s7_300/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/s7_300/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">S7 300</name>
         <name lang="en">S7 300</name>

--- a/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/sinumerik/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/01_PLC_controllers/sinumerik/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Sinumerik</name>
         <name lang="en">Sinumerik</name>

--- a/10_electric/20_manufacturers_articles/siemens/02_human_machine_interface/terminal_operateur/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/02_human_machine_interface/terminal_operateur/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Obslužné panely</name>
         <name lang="de">Bedienpanel</name>

--- a/10_electric/20_manufacturers_articles/siemens/05_bus_topology/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/05_bus_topology/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="M">
     <names>
         <name lang="cs">Síťová topologie</name>
         <name lang="de">Bustopologie</name>

--- a/10_electric/20_manufacturers_articles/siemens/10_softstarter/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/10_softstarter/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="Q">
     <names>
         <name lang="ar">بادئات حركة تدريجية</name>
         <name lang="cs">Softstartéry</name>

--- a/10_electric/20_manufacturers_articles/siemens/20_frequency_drives/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/20_frequency_drives/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="T">
     <names>
         <name lang="ar">مُغيّرات تردّد</name>
         <name lang="cs">Frekvenční měniče</name>

--- a/10_electric/20_manufacturers_articles/siemens/71_asynchronous_motors/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/71_asynchronous_motors/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="M">
     <names>
         <name lang="cs">Asynchronní motory</name>
         <name lang="de">Asynchronmotoren</name>

--- a/10_electric/20_manufacturers_articles/siemens/73_servo_motors/qet_directory
+++ b/10_electric/20_manufacturers_articles/siemens/73_servo_motors/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="M">
     <names>
         <name lang="cs">Servomotory</name>
         <name lang="de">Servomotoren</name>

--- a/10_electric/20_manufacturers_articles/smc/qet_directory
+++ b/10_electric/20_manufacturers_articles/smc/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="cs">SMC</name>
         <name lang="de">SMC</name>

--- a/10_electric/20_manufacturers_articles/socomec/qet_directory
+++ b/10_electric/20_manufacturers_articles/socomec/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="P">
     <names>
         <name lang="cs">Socomec</name>
         <name lang="en">Socomec</name>

--- a/10_electric/20_manufacturers_articles/sofrel/01_PLC_controllers/s4th/qet_directory
+++ b/10_electric/20_manufacturers_articles/sofrel/01_PLC_controllers/s4th/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">S4 TH</name>
         <name lang="fr">S4 TH</name>

--- a/10_electric/20_manufacturers_articles/sofrel/01_PLC_controllers/s500/qet_directory
+++ b/10_electric/20_manufacturers_articles/sofrel/01_PLC_controllers/s500/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">S500</name>
         <name lang="de">S500</name>

--- a/10_electric/20_manufacturers_articles/tele-haase/qet_directory
+++ b/10_electric/20_manufacturers_articles/tele-haase/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="H">
     <names>
         <name lang="cs">Tele-haase</name>
         <name lang="en">Tele-haase</name>

--- a/10_electric/20_manufacturers_articles/telemecanique/20_frequency_drives/qet_directory
+++ b/10_electric/20_manufacturers_articles/telemecanique/20_frequency_drives/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="T">
     <names>
         <name lang="ar">مُغيّرات تردّد</name>
         <name lang="cs">Frekvenční měniče</name>

--- a/10_electric/20_manufacturers_articles/trendnet/qet_directory
+++ b/10_electric/20_manufacturers_articles/trendnet/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="de">Trendnet</name>
         <name lang="en">Trendnet</name>

--- a/10_electric/20_manufacturers_articles/unitronics_plc/qet_directory
+++ b/10_electric/20_manufacturers_articles/unitronics_plc/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Unitronics PLC</name>
         <name lang="en">Unitronics PLC</name>

--- a/10_electric/20_manufacturers_articles/vega/qet_directory
+++ b/10_electric/20_manufacturers_articles/vega/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="cs">Vega</name>
         <name lang="de">Vega</name>

--- a/10_electric/20_manufacturers_articles/victron/qet_directory
+++ b/10_electric/20_manufacturers_articles/victron/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="P">
     <names>
         <name lang="en">Victron</name>
         <name lang="pt_BR">Victron</name>

--- a/10_electric/20_manufacturers_articles/wago/01_schematic/0286_pluggable_modules/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/01_schematic/0286_pluggable_modules/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="U">
     <names>
         <name lang="cs">Zásuvné moduly na svorkovnici</name>
         <name lang="de">Steckbare Bausteine auf Basisklemmenblock</name>

--- a/10_electric/20_manufacturers_articles/wago/01_schematic/0750_io_750/010_pfc/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/01_schematic/0750_io_750/010_pfc/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">PLC - Kontrolér PFC</name>
         <name lang="da">SPS - Controller PFC</name>

--- a/10_electric/20_manufacturers_articles/wago/01_schematic/0750_io_750/020_controller/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/01_schematic/0750_io_750/020_controller/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Kontrolér</name>
         <name lang="da">Controller</name>

--- a/10_electric/20_manufacturers_articles/wago/01_schematic/0750_io_750_xtr/010_pfc/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/01_schematic/0750_io_750_xtr/010_pfc/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">SPS - Controller PFC XTR</name>
         <name lang="da">SPS - Controller PFC XTR</name>

--- a/10_electric/20_manufacturers_articles/wago/01_schematic/0750_io_750_xtr/020_controller/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/01_schematic/0750_io_750_xtr/020_controller/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Controller XTR</name>
         <name lang="da">Controller XTR</name>

--- a/10_electric/20_manufacturers_articles/wago/01_schematic/0752_edge/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/01_schematic/0752_edge/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Edge Devices</name>
         <name lang="da">Edge Devices</name>

--- a/10_electric/20_manufacturers_articles/wago/01_schematic/0787_power-supplies/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/01_schematic/0787_power-supplies/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="G">
     <names>
         <name lang="cs">Napájecí zdroje</name>
         <name lang="da">Power-Supplies</name>

--- a/10_electric/20_manufacturers_articles/wago/01_schematic/0788_relay-modules/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/01_schematic/0788_relay-modules/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Reléové moduly</name>
         <name lang="de">Relaismodule</name>

--- a/10_electric/20_manufacturers_articles/wago/01_schematic/0859_electronicterminalblocks/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/01_schematic/0859_electronicterminalblocks/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="U">
     <names>
         <name lang="cs">Elektronické svorkovnicové bloky 859</name>
         <name lang="da">Electronic Terminal Blocks 859</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_accessories/0001_mounting-rails/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_accessories/0001_mounting-rails/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="U">
     <names>
         <name lang="cs">Montážní lišta</name>
         <name lang="de">Tragschienen</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_accessories/0002_supports/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_accessories/0002_supports/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="N">
     <names>
         <name lang="cs">Podpěry a držáky</name>
         <name lang="de">Stützen und Halterungen</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_accessories/0003_installation-devices/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_accessories/0003_installation-devices/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Instalační zařízení</name>
         <name lang="de">Installations-Geräte</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/0000_jumpers/0280_jumpers/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/0000_jumpers/0280_jumpers/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Můstky pro sérii 280, 769</name>
         <name lang="da">Jumpers for Series 280, 769</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/0000_jumpers/0859_jumpers/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/0000_jumpers/0859_jumpers/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Můstky pro sérii 859</name>
         <name lang="da">Jumpers for Series 859</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/0000_jumpers/2000_jumpers/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/0000_jumpers/2000_jumpers/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Series 2000</name>
         <name lang="da">Series 2000</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/0000_jumpers/2001_jumpers/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/0000_jumpers/2001_jumpers/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Series 2001</name>
         <name lang="da">Series 2001</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/0000_jumpers/2002_jumpers/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/0000_jumpers/2002_jumpers/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Series 2002</name>
         <name lang="da">Series 2002</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/0000_jumpers/2004_jumpers/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/0000_jumpers/2004_jumpers/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Series 2004</name>
         <name lang="da">Series 2004</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/0000_jumpers/2006_jumpers/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/0000_jumpers/2006_jumpers/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Series 2006</name>
         <name lang="da">Series 2006</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/0000_jumpers/2010_jumpers/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/0000_jumpers/2010_jumpers/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Series 2010</name>
         <name lang="da">Series 2010</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/0000_jumpers/2016_jumpers/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/0000_jumpers/2016_jumpers/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Series 2016</name>
         <name lang="da">Series 2016</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/0285_terminals/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/0285_terminals/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Řada 285</name>
         <name lang="da">Series 285</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/0769_terminals/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/0769_terminals/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Řada 769</name>
         <name lang="da">Series 769</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/0870_terminals/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/0870_terminals/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Řada 870</name>
         <name lang="da">Series 870</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2000_terminals/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2000_terminals/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Řada 2000</name>
         <name lang="da">Series 2000</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2001_terminals/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2001_terminals/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Řada 2001</name>
         <name lang="da">Series 2001</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2002_terminals/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2002_terminals/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Řada 2002</name>
         <name lang="da">Series 2002</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2003_terminals/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2003_terminals/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Řada 2003</name>
         <name lang="da">Series 2003</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2004_terminals/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2004_terminals/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Řada 2004</name>
         <name lang="da">Series 2004</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2006_terminals/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2006_terminals/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Řada 2006</name>
         <name lang="da">Series 2006</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2010_terminals/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2010_terminals/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Řada 2010</name>
         <name lang="da">Series 2010</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2016_terminals/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2016_terminals/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Řada 2016</name>
         <name lang="da">Series 2016</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2020_terminals/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2020_terminals/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Řada 2020</name>
         <name lang="da">Series 2020</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2022_terminals/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2022_terminals/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Řada 2022</name>
         <name lang="da">Series 2022</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2102_terminals/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2102_terminals/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Řada 2102</name>
         <name lang="da">Series 2102</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2104_terminals/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2104_terminals/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Řada 2104</name>
         <name lang="da">Series 2104</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2106_terminals/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2106_terminals/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Řada 2106</name>
         <name lang="da">Series 2106</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2110_terminals/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2110_terminals/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Řada 2110</name>
         <name lang="da">Series 2110</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2116_terminals/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2116_terminals/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Řada 2116</name>
         <name lang="da">Series 2116</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2200_terminals/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2200_terminals/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Řada 2200</name>
         <name lang="da">Series 2200</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2201_terminals/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2201_terminals/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Řada 2201</name>
         <name lang="da">Series 2201</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2202_terminals/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2202_terminals/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Řada 2202</name>
         <name lang="da">Series 2202</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2204_terminals/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2204_terminals/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Řada 2204</name>
         <name lang="da">Series 2204</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2206_terminals/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2206_terminals/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Řada 2206</name>
         <name lang="da">Series 2206</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2210_terminals/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2210_terminals/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Řada 2210</name>
         <name lang="da">Series 2210</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2216_terminals/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0000_terminals/2216_terminals/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Řada 2216</name>
         <name lang="da">Series 2216</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0289_interfacemodules/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0289_interfacemodules/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="cs">Moduly rozhraní 289</name>
         <name lang="da">Interface-Modules 289</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0750_io_750/010_pfc/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0750_io_750/010_pfc/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">SPS - Controller PFC</name>
         <name lang="da">SPS - Controller PFC</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0750_io_750/020_controller/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0750_io_750/020_controller/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Controller</name>
         <name lang="da">Controller</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0750_io_750/zzz_templates/0001_8-pole_led/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0750_io_750/zzz_templates/0001_8-pole_led/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="E">
     <names>
         <name lang="cs">8-pole LED</name>
         <name lang="de">8-pol. LED</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0750_io_750/zzz_templates/0002_8-pole_lightconductor/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0750_io_750/zzz_templates/0002_8-pole_lightconductor/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="W">
     <names>
         <name lang="cs">8-pole Light-Cond.</name>
         <name lang="de">8-pol. Lichtleiter</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0750_io_750/zzz_templates/0011_io_750_ex_i/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0750_io_750/zzz_templates/0011_io_750_ex_i/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="W">
     <names>
         <name lang="cs">I/O 750 Ex i</name>
         <name lang="da">I/O 750 Ex i</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0750_io_750/zzz_templates/0012_io_750_profisafe/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0750_io_750/zzz_templates/0012_io_750_profisafe/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="W">
     <names>
         <name lang="cs">I/O 750 PROFIsafe</name>
         <name lang="da">I/O 750 PROFIsafe</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0750_io_750_xtr/010_pfc/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0750_io_750_xtr/010_pfc/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">PLC - Kontrolér PFC</name>
         <name lang="da">SPS - Controller PFC</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0750_io_750_xtr/020_controller/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0750_io_750_xtr/020_controller/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Kontroléry</name>
         <name lang="da">Controller</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0750_io_750_xtr/zzz_templates/050_8-pole/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0750_io_750_xtr/zzz_templates/050_8-pole/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="W">
     <names>
         <name lang="cs">8-pole Light-Cond.</name>
         <name lang="de">8-pol. Lichtleiter</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0752_edge/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0752_edge/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Edge Devices</name>
         <name lang="da">Edge Devices</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0753_io_753/zzz_templates/0001_8-pole_led/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0753_io_753/zzz_templates/0001_8-pole_led/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="E">
     <names>
         <name lang="cs">8-pole LED</name>
         <name lang="de">8-pol. LED</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0753_io_753/zzz_templates/0002_8-pole_lightconductor/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0753_io_753/zzz_templates/0002_8-pole_lightconductor/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="W">
     <names>
         <name lang="cs">8-pole Light-Cond.</name>
         <name lang="de">8-pol. Lichtleiter</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0787_power-supplies/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0787_power-supplies/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="G">
     <names>
         <name lang="cs">Napájecí zdroje</name>
         <name lang="da">Power-Supplies</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0788_relay-modules/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0788_relay-modules/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Reléové moduly</name>
         <name lang="de">Relaismodule</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0789_installationdevices/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0789_installationdevices/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Instalační přístroje 789</name>
         <name lang="da">Installation Devices 789</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0858_relay-modules/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0858_relay-modules/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Reléové moduly Serie 858</name>
         <name lang="de">Relaismodule Serie 858</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0859_electronicterminalblocks/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0859_electronicterminalblocks/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="U">
     <names>
         <name lang="cs">Svorkovnice s relé a optočleny 859</name>
         <name lang="da">Electronic Terminal Blocks 859</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0890_winsta/0001_mini_2p/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0890_winsta/0001_mini_2p/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Series 890 - MINI - 2p</name>
         <name lang="de">Serie 890 - MINI - 2p</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0890_winsta/0001_mini_3p/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0890_winsta/0001_mini_3p/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Series 890 - MINI - 3p</name>
         <name lang="de">Serie 890 - MINI - 3p</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0890_winsta/0002_midi_3p/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0890_winsta/0002_midi_3p/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Series 770 - MIDI - 3p</name>
         <name lang="de">Serie 770 - MIDI - 3p</name>

--- a/10_electric/20_manufacturers_articles/wago/02_front/0890_winsta/0002_midi_5p/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/02_front/0890_winsta/0002_midi_5p/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Series 770 - MIDI - 5p</name>
         <name lang="de">Serie 770 - MIDI - 5p</name>

--- a/10_electric/20_manufacturers_articles/wago/zz_discontinued/01_schematic/0750_io_750/010_pfc/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/zz_discontinued/01_schematic/0750_io_750/010_pfc/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">PLC - Kontrolér PFC</name>
         <name lang="da">SPS - Controller PFC</name>

--- a/10_electric/20_manufacturers_articles/wago/zz_discontinued/01_schematic/0750_io_750/020_controller/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/zz_discontinued/01_schematic/0750_io_750/020_controller/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Kontrolér</name>
         <name lang="da">Controller</name>

--- a/10_electric/20_manufacturers_articles/wago/zz_discontinued/02_front/0000_terminals/0280_terminals/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/zz_discontinued/02_front/0000_terminals/0280_terminals/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Řada 280</name>
         <name lang="da">Series 280</name>

--- a/10_electric/20_manufacturers_articles/wago/zz_discontinued/02_front/0750_io_750/010_pfc/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/zz_discontinued/02_front/0750_io_750/010_pfc/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">SPS - Controller PFC</name>
         <name lang="da">SPS - Controller PFC</name>

--- a/10_electric/20_manufacturers_articles/wago/zz_discontinued/02_front/0750_io_750/020_controller/qet_directory
+++ b/10_electric/20_manufacturers_articles/wago/zz_discontinued/02_front/0750_io_750/020_controller/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Controller</name>
         <name lang="da">Controller</name>

--- a/10_electric/20_manufacturers_articles/warner/qet_directory
+++ b/10_electric/20_manufacturers_articles/warner/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Warner</name>
         <name lang="en">Warner</name>

--- a/10_electric/20_manufacturers_articles/weidmuller/qet_directory
+++ b/10_electric/20_manufacturers_articles/weidmuller/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="cs">Weidmüller</name>
         <name lang="de">Weidmüller</name>

--- a/10_electric/20_manufacturers_articles/west/qet_directory
+++ b/10_electric/20_manufacturers_articles/west/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="P">
     <names>
         <name lang="cs">West</name>
         <name lang="de">West</name>

--- a/10_electric/90_american_standards/15_allpole/140_connectors_plugs/01_connectors_pins/qet_directory
+++ b/10_electric/90_american_standards/15_allpole/140_connectors_plugs/01_connectors_pins/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">Zásuvkové kontakty</name>
         <name lang="de">Steckkontakte</name>

--- a/10_electric/90_american_standards/15_allpole/200_fuses_protective_gears/11_circuit_breakers/qet_directory
+++ b/10_electric/90_american_standards/15_allpole/200_fuses_protective_gears/11_circuit_breakers/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="Q">
     <names>
         <name lang="ar">قواطع</name>
         <name lang="cs">Jističe</name>

--- a/10_electric/91_en_60617/en_60617_02/en_60617_02_02/qet_directory
+++ b/10_electric/91_en_60617/en_60617_02/en_60617_02_02/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="W">
     <names>
         <name lang="cs">02- Druhy proudu a napětí</name>
         <name lang="de">02- Arten von Strömen und Spannungen</name>

--- a/10_electric/91_en_60617/en_60617_02/en_60617_02_05/qet_directory
+++ b/10_electric/91_en_60617/en_60617_02/en_60617_02_05/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="W">
     <names>
         <name lang="cs">05- Směr toku</name>
         <name lang="de">05- Wirkungsrichtung</name>

--- a/10_electric/91_en_60617/en_60617_02/en_60617_02_08/qet_directory
+++ b/10_electric/91_en_60617/en_60617_02/en_60617_02_08/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">08- Účinek nebo závislost</name>
         <name lang="de">08- Arten von Wirkungen oder Abhängigkeiten</name>

--- a/10_electric/91_en_60617/en_60617_02/en_60617_02_13/qet_directory
+++ b/10_electric/91_en_60617/en_60617_02/en_60617_02_13/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="M">
     <names>
         <name lang="cs">13- Ovládací zařízení (akční členy), soubor 1</name>
         <name lang="de">13- Steller, Satz 1</name>

--- a/10_electric/91_en_60617/en_60617_02/en_60617_02_14/qet_directory
+++ b/10_electric/91_en_60617/en_60617_02/en_60617_02_14/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="M">
     <names>
         <name lang="cs">14- Ovládací zařízení ( akční členy), soubor 2</name>
         <name lang="de">14- Steller, Satz 2</name>

--- a/10_electric/91_en_60617/en_60617_02/en_60617_02_17/qet_directory
+++ b/10_electric/91_en_60617/en_60617_02/en_60617_02_17/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="P">
     <names>
         <name lang="cs">17- Různé</name>
         <name lang="de">17- Verschiedenes</name>

--- a/10_electric/91_en_60617/en_60617_03/en_60617_03_01/qet_directory
+++ b/10_electric/91_en_60617/en_60617_03/en_60617_03_01/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="W">
     <names>
         <name lang="cs">01- Spojení</name>
         <name lang="de">01- Leiter</name>

--- a/10_electric/91_en_60617/en_60617_03/en_60617_03_02/qet_directory
+++ b/10_electric/91_en_60617/en_60617_03/en_60617_03_02/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">02- Spojení, svorky a odbočení</name>
         <name lang="de">02- Anschlüsse und Leiterverbindungen</name>

--- a/10_electric/91_en_60617/en_60617_03/en_60617_03_03/qet_directory
+++ b/10_electric/91_en_60617/en_60617_03/en_60617_03_03/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">03- Spojovací součásti</name>
         <name lang="de">03- Verbinder</name>

--- a/10_electric/91_en_60617/en_60617_03/en_60617_03_04/qet_directory
+++ b/10_electric/91_en_60617/en_60617_03/en_60617_03_04/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="W">
     <names>
         <name lang="cs">04- Příslušenství pro kabely</name>
         <name lang="de">04- Kabelverbinder</name>

--- a/10_electric/91_en_60617/en_60617_04/en_60617_04_01/qet_directory
+++ b/10_electric/91_en_60617/en_60617_04/en_60617_04_01/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="R">
     <names>
         <name lang="cs">01- Rezistory</name>
         <name lang="de">01- Widerstände</name>

--- a/10_electric/91_en_60617/en_60617_04/en_60617_04_02/qet_directory
+++ b/10_electric/91_en_60617/en_60617_04/en_60617_04_02/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="C">
     <names>
         <name lang="cs">02- Kondenzátory</name>
         <name lang="de">02- Kondensatoren</name>

--- a/10_electric/91_en_60617/en_60617_04/en_60617_04_03/qet_directory
+++ b/10_electric/91_en_60617/en_60617_04/en_60617_04_03/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="R">
     <names>
         <name lang="cs">03- Indukční cívky</name>
         <name lang="de">03- Induktivitäten</name>

--- a/10_electric/91_en_60617/en_60617_04/en_60617_04_04/qet_directory
+++ b/10_electric/91_en_60617/en_60617_04/en_60617_04_04/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="P">
     <names>
         <name lang="cs">04- Prvky značek</name>
         <name lang="de">04- Symbolelemente</name>

--- a/10_electric/91_en_60617/en_60617_04/en_60617_04_07/qet_directory
+++ b/10_electric/91_en_60617/en_60617_04/en_60617_04_07/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="cs">07- Piezoelektrické jednotky, elektret</name>
         <name lang="de">07- Piezoelektrische Kristalle, Elektret</name>

--- a/10_electric/91_en_60617/en_60617_05/en_60617_05_01/qet_directory
+++ b/10_electric/91_en_60617/en_60617_05/en_60617_05_01/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">01- Prvky značek</name>
         <name lang="de">01- Symbolelemente</name>

--- a/10_electric/91_en_60617/en_60617_05/en_60617_05_02/qet_directory
+++ b/10_electric/91_en_60617/en_60617_05/en_60617_05_02/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">02- Doplňkové značky pro polovodičové součástky</name>
         <name lang="de">02- Besondere Kennzeichen für Halbleiterelemente</name>

--- a/10_electric/91_en_60617/en_60617_05/en_60617_05_03/qet_directory
+++ b/10_electric/91_en_60617/en_60617_05/en_60617_05_03/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">03- Příklady polovodičových diod</name>
         <name lang="de">03- Beispiele für Halbleiterdioden</name>

--- a/10_electric/91_en_60617/en_60617_05/en_60617_05_04/qet_directory
+++ b/10_electric/91_en_60617/en_60617_05/en_60617_05_04/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">04- Příklady tyristorů</name>
         <name lang="de">04- Beispiele für Thyristoren</name>

--- a/10_electric/91_en_60617/en_60617_05/en_60617_05_05/qet_directory
+++ b/10_electric/91_en_60617/en_60617_05/en_60617_05_05/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">05- Příklady tranzistorů</name>
         <name lang="de">05- Beispiele für Transistoren</name>

--- a/10_electric/91_en_60617/en_60617_05/en_60617_05_06/qet_directory
+++ b/10_electric/91_en_60617/en_60617_05/en_60617_05_06/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">06- Příklady fotoelektrických součástek a součástek citlivých na magnetické pole</name>
         <name lang="de">06- Beispiele für licht- und magnetfeldempfindliche Elemente</name>

--- a/10_electric/91_en_60617/en_60617_05/en_60617_05_07/qet_directory
+++ b/10_electric/91_en_60617/en_60617_05/en_60617_05_07/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">07- Elektronky, prvky značek, všeobecně</name>
         <name lang="de">07- Symbolelemente, allgemein</name>

--- a/10_electric/91_en_60617/en_60617_05/en_60617_05_08/qet_directory
+++ b/10_electric/91_en_60617/en_60617_05/en_60617_05_08/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="cs">08- Prvky značek pro obrazovky a televizní snímací elektronky</name>
         <name lang="de">08- Symbolelemente für Kathodenstrahl und Bildaufnahmeröhren</name>

--- a/10_electric/91_en_60617/en_60617_05/en_60617_05_09/qet_directory
+++ b/10_electric/91_en_60617/en_60617_05/en_60617_05_09/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">09- Značky použitelné většinou pro mikrovlnné elektronky</name>
         <name lang="de">09- Symbolelemente für Mikrowellenröhren</name>

--- a/10_electric/91_en_60617/en_60617_05/en_60617_05_10/qet_directory
+++ b/10_electric/91_en_60617/en_60617_05/en_60617_05_10/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">10- Prvky značek pro různé elektronky včetně rtuťových usměrňovačů</name>
         <name lang="de">10- Symbolelemente für weiter Röhrenarten, einschliesslich Quecksilberdampfröhren</name>

--- a/10_electric/91_en_60617/en_60617_05/en_60617_05_11/qet_directory
+++ b/10_electric/91_en_60617/en_60617_05/en_60617_05_11/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">11- Příklady elektronek</name>
         <name lang="de">11- Beispiele für Elektronenröhren</name>

--- a/10_electric/91_en_60617/en_60617_05/en_60617_05_13/qet_directory
+++ b/10_electric/91_en_60617/en_60617_05/en_60617_05_13/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">13- Příklady mikrovlnných elektronek</name>
         <name lang="de">13- Beispiele für Mikrowellenröhren</name>

--- a/10_electric/91_en_60617/en_60617_05/en_60617_05_16/qet_directory
+++ b/10_electric/91_en_60617/en_60617_05/en_60617_05_16/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">16- Elektrochemické součástky</name>
         <name lang="de">16- Elektrochemische Geräte</name>

--- a/10_electric/91_en_60617/en_60617_06/en_60617_06_01/qet_directory
+++ b/10_electric/91_en_60617/en_60617_06/en_60617_06_01/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="W">
     <names>
         <name lang="cs">01- Oddělená vinutí</name>
         <name lang="de">01- Getrennte Wicklungen</name>

--- a/10_electric/91_en_60617/en_60617_06/en_60617_06_04/qet_directory
+++ b/10_electric/91_en_60617/en_60617_06/en_60617_06_04/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="M">
     <names>
         <name lang="cs">04- Druhy strojů</name>
         <name lang="de">04- Maschinenarten</name>

--- a/10_electric/91_en_60617/en_60617_06/en_60617_06_05/qet_directory
+++ b/10_electric/91_en_60617/en_60617_06/en_60617_06_05/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="M">
     <names>
         <name lang="cs">05- Příklady stejnosměrných strojů</name>
         <name lang="de">05- Beispiele für Gleichstrommaschinen</name>

--- a/10_electric/91_en_60617/en_60617_06/en_60617_06_06/qet_directory
+++ b/10_electric/91_en_60617/en_60617_06/en_60617_06_06/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="M">
     <names>
         <name lang="cs">06- Příklady střídavých komutátorových strojů</name>
         <name lang="de">06- Beispiele für Wechselstrom-Kommutatormaschinen</name>

--- a/10_electric/91_en_60617/en_60617_06/en_60617_06_07/qet_directory
+++ b/10_electric/91_en_60617/en_60617_06/en_60617_06_07/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="G">
     <names>
         <name lang="cs">07- Příklady synchronních strojů</name>
         <name lang="de">07- Beispiele für Synchronmaschinen</name>

--- a/10_electric/91_en_60617/en_60617_06/en_60617_06_08/qet_directory
+++ b/10_electric/91_en_60617/en_60617_06/en_60617_06_08/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="M">
     <names>
         <name lang="cs">08- Příklady indukčních typů (asynchronních) strojů</name>
         <name lang="de">08- Beispiele für Asynchronmaschinen</name>

--- a/10_electric/91_en_60617/en_60617_06/en_60617_06_09/qet_directory
+++ b/10_electric/91_en_60617/en_60617_06/en_60617_06_09/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="T">
     <names>
         <name lang="cs">09- Všeobecné symboly a značky pro transformátory a tlumivky</name>
         <name lang="de">09- Allgemeine Symbole für Transformatoren und Drosseln</name>

--- a/10_electric/91_en_60617/en_60617_06/en_60617_06_10/qet_directory
+++ b/10_electric/91_en_60617/en_60617_06/en_60617_06_10/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="T">
     <names>
         <name lang="cs">10- Příklady transformátorů s oddělenými vinutími</name>
         <name lang="de">10- Beispiele für Transformatren mit getrennten Wicklungen</name>

--- a/10_electric/91_en_60617/en_60617_06/en_60617_06_11/qet_directory
+++ b/10_electric/91_en_60617/en_60617_06/en_60617_06_11/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="T">
     <names>
         <name lang="cs">11- Příklady autotransformátorů</name>
         <name lang="de">11- Beispiele für Spartransformatoren</name>

--- a/10_electric/91_en_60617/en_60617_06/en_60617_06_13/qet_directory
+++ b/10_electric/91_en_60617/en_60617_06/en_60617_06_13/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="T">
     <names>
         <name lang="cs">13- Příklady měřicích a pulzních transformátorů</name>
         <name lang="de">13- Beispiele für Messwandler und Impulstransformatoren</name>

--- a/10_electric/91_en_60617/en_60617_06/en_60617_06_14/qet_directory
+++ b/10_electric/91_en_60617/en_60617_06/en_60617_06_14/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="T">
     <names>
         <name lang="cs">14- Blokové značky pro výkonové převodníky-měniče</name>
         <name lang="de">14- Blocksymbole für Leistungsumrichter</name>

--- a/10_electric/91_en_60617/en_60617_06/en_60617_06_15/qet_directory
+++ b/10_electric/91_en_60617/en_60617_06/en_60617_06_15/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="G">
     <names>
         <name lang="cs">15- Primární a sekundární články</name>
         <name lang="de">15- Primärzellen und Akkumulatoren</name>

--- a/10_electric/91_en_60617/en_60617_06/en_60617_06_16/qet_directory
+++ b/10_electric/91_en_60617/en_60617_06/en_60617_06_16/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="G">
     <names>
         <name lang="cs">16- Všeobecná značka pro nerotační výkonové generátory</name>
         <name lang="de">16- Grundsymbol für nicht rotierende Generatoren, Heizquellen</name>

--- a/10_electric/91_en_60617/en_60617_06/en_60617_06_18/qet_directory
+++ b/10_electric/91_en_60617/en_60617_06/en_60617_06_18/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="G">
     <names>
         <name lang="cs">18- Příklady výkonových generátorů</name>
         <name lang="de">18- Beispiele für besondere, rotierende Generatoren</name>

--- a/10_electric/91_en_60617/en_60617_06/en_60617_06_19/qet_directory
+++ b/10_electric/91_en_60617/en_60617_06/en_60617_06_19/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">19- Regulátory se zpětnou vazbou</name>
         <name lang="de">19- Regler</name>

--- a/10_electric/91_en_60617/en_60617_07/en_60617_07_01/qet_directory
+++ b/10_electric/91_en_60617/en_60617_07/en_60617_07_01/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="Q">
     <names>
         <name lang="cs">01- Doplňkové značky</name>
         <name lang="de">01- Kennzeichen</name>

--- a/10_electric/91_en_60617/en_60617_07/en_60617_07_02/qet_directory
+++ b/10_electric/91_en_60617/en_60617_07/en_60617_07_02/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="cs">02- Kontakty se dvěma nebo třemi polohami</name>
         <name lang="de">02- Kontakte mit zwei oder drei Schaltstellungen</name>

--- a/10_electric/91_en_60617/en_60617_07/en_60617_07_07/qet_directory
+++ b/10_electric/91_en_60617/en_60617_07/en_60617_07_07/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="cs">07- Jednopólové spínače</name>
         <name lang="de">07- Handbetätigte Schalter</name>

--- a/10_electric/91_en_60617/en_60617_07/en_60617_07_08/qet_directory
+++ b/10_electric/91_en_60617/en_60617_07/en_60617_07_08/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="cs">08- Polohové spínače</name>
         <name lang="de">08- Grenzschalter, Endschalter</name>

--- a/10_electric/91_en_60617/en_60617_07/en_60617_07_09/qet_directory
+++ b/10_electric/91_en_60617/en_60617_07/en_60617_07_09/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="cs">09- Spínače citlivé na teplotu</name>
         <name lang="de">09- Temperaturabhängige Schalter</name>

--- a/10_electric/91_en_60617/en_60617_07/en_60617_07_11/qet_directory
+++ b/10_electric/91_en_60617/en_60617_07/en_60617_07_11/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="cs">11- Příklady vícepolohových spínačů, včetně ovládacích spínačů</name>
         <name lang="de">11- Beispiele Mehrstellungsschalter</name>

--- a/10_electric/91_en_60617/en_60617_07/en_60617_07_12/qet_directory
+++ b/10_electric/91_en_60617/en_60617_07/en_60617_07_12/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="cs">12- Blokové značky složitých spínačů</name>
         <name lang="de">12- Blocksymbole für komplexe Schalter</name>

--- a/10_electric/91_en_60617/en_60617_07/en_60617_07_13/qet_directory
+++ b/10_electric/91_en_60617/en_60617_07/en_60617_07_13/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="Q">
     <names>
         <name lang="cs">13- Silová spínací zařízení</name>
         <name lang="de">13- Schaltgeräte und Steuergeräte</name>

--- a/10_electric/91_en_60617/en_60617_07/en_60617_07_14/qet_directory
+++ b/10_electric/91_en_60617/en_60617_07/en_60617_07_14/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="Q">
     <names>
         <name lang="cs">14- Blokové značky motorových spouštěčů</name>
         <name lang="de">14- Blocksymbole für Anlasser</name>

--- a/10_electric/91_en_60617/en_60617_07/en_60617_07_15/qet_directory
+++ b/10_electric/91_en_60617/en_60617_07/en_60617_07_15/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">15- Ovládací ústrojí</name>
         <name lang="de">15- Elektromechanische Antriebe</name>

--- a/10_electric/91_en_60617/en_60617_07/en_60617_07_16/qet_directory
+++ b/10_electric/91_en_60617/en_60617_07/en_60617_07_16/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">16- Měřicí relé a odvozená zařízení</name>
         <name lang="de">16- Blocksymbole und Kennzeichen für Messrelais und verwandte Einrichtungen</name>

--- a/10_electric/91_en_60617/en_60617_07/en_60617_07_17/qet_directory
+++ b/10_electric/91_en_60617/en_60617_07/en_60617_07_17/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">17- Příklady měřicích relé</name>
         <name lang="de">17- Beispiele für Messrelais</name>

--- a/10_electric/91_en_60617/en_60617_07/en_60617_07_18/qet_directory
+++ b/10_electric/91_en_60617/en_60617_07/en_60617_07_18/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">18- Další zařízení</name>
         <name lang="de">18- Andere Einrichtungen</name>

--- a/10_electric/91_en_60617/en_60617_07/en_60617_07_19/qet_directory
+++ b/10_electric/91_en_60617/en_60617_07/en_60617_07_19/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="cs">19- Zařízení citlivá na přiblížení a dotyk</name>
         <name lang="de">19- Sensoren und Detektoren</name>

--- a/10_electric/91_en_60617/en_60617_07/en_60617_07_20/qet_directory
+++ b/10_electric/91_en_60617/en_60617_07/en_60617_07_20/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="cs">20- Spínače</name>
         <name lang="de">20- Schalter</name>

--- a/10_electric/91_en_60617/en_60617_07/en_60617_07_21/qet_directory
+++ b/10_electric/91_en_60617/en_60617_07/en_60617_07_21/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="F">
     <names>
         <name lang="cs">21- Tavné pojistky a vypínací pojistky</name>
         <name lang="de">21- Sicherungen und Sicherungsschalter</name>

--- a/10_electric/91_en_60617/en_60617_07/en_60617_07_22/qet_directory
+++ b/10_electric/91_en_60617/en_60617_07/en_60617_07_22/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="F">
     <names>
         <name lang="cs">22- Jiskřiště a bleskojistky</name>
         <name lang="de">22- Funkenstrecken und Überspannungsableiter</name>

--- a/10_electric/91_en_60617/en_60617_07/en_60617_07_25/qet_directory
+++ b/10_electric/91_en_60617/en_60617_07/en_60617_07_25/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="cs">25- Statické spínače</name>
         <name lang="de">25- Elektronische Schalter</name>

--- a/10_electric/91_en_60617/en_60617_07/en_60617_07_26/qet_directory
+++ b/10_electric/91_en_60617/en_60617_07/en_60617_07_26/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">26- Statické spínací přístroje</name>
         <name lang="de">26- Elektronische Schalteinrichtungen</name>

--- a/10_electric/91_en_60617/en_60617_07/en_60617_07_27/qet_directory
+++ b/10_electric/91_en_60617/en_60617_07/en_60617_07_27/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">27- Vazební členy a statická relé</name>
         <name lang="de">27- Koppler und Elektronische Relais, Blocksymbole</name>

--- a/10_electric/91_en_60617/en_60617_08/en_60617_08_01/qet_directory
+++ b/10_electric/91_en_60617/en_60617_08/en_60617_08_01/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="P">
     <names>
         <name lang="cs">01- Indikační, zapisovací a integrační přístroje</name>
         <name lang="de">01- Anzeigende, aufzeichnende und integrierende Messgeräte, allgemeine Schaltzeichen</name>

--- a/10_electric/91_en_60617/en_60617_08/en_60617_08_02/qet_directory
+++ b/10_electric/91_en_60617/en_60617_08/en_60617_08_02/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="E">
     <names>
         <name lang="cs">02- Příklady indikačních přístrojů</name>
         <name lang="de">02- Beispiele für anzeigende Messgeräte</name>

--- a/10_electric/91_en_60617/en_60617_08/en_60617_08_03/qet_directory
+++ b/10_electric/91_en_60617/en_60617_08/en_60617_08_03/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="E">
     <names>
         <name lang="cs">03- Příklady zapisovacích přístrojů</name>
         <name lang="de">03- Beispiele für aufzeichnende Messgeräte</name>

--- a/10_electric/91_en_60617/en_60617_08/en_60617_08_04/qet_directory
+++ b/10_electric/91_en_60617/en_60617_08/en_60617_08_04/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="P">
     <names>
         <name lang="cs">04- Příklady integračních přístrojů</name>
         <name lang="de">04- Beispiele für integrierende Messgeräte</name>

--- a/10_electric/91_en_60617/en_60617_08/en_60617_08_05/qet_directory
+++ b/10_electric/91_en_60617/en_60617_08/en_60617_08_05/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="P">
     <names>
         <name lang="cs">05- Čítače</name>
         <name lang="de">05- Zähleinrichtungen</name>

--- a/10_electric/91_en_60617/en_60617_08/en_60617_08_06/qet_directory
+++ b/10_electric/91_en_60617/en_60617_08/en_60617_08_06/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="E">
     <names>
         <name lang="cs">06- Termočlánky</name>
         <name lang="de">06- Thermoelemente</name>

--- a/10_electric/91_en_60617/en_60617_08/en_60617_08_07/qet_directory
+++ b/10_electric/91_en_60617/en_60617_08/en_60617_08_07/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="E">
     <names>
         <name lang="cs">07- Zařízení pro dálkové měření</name>
         <name lang="de">07- Fernmesseinrichtungen</name>

--- a/10_electric/91_en_60617/en_60617_08/en_60617_08_08/qet_directory
+++ b/10_electric/91_en_60617/en_60617_08/en_60617_08_08/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="E">
     <names>
         <name lang="cs">08- Elektrické hodiny</name>
         <name lang="de">08- Elektrische Uhren</name>

--- a/10_electric/91_en_60617/en_60617_08/en_60617_08_09/qet_directory
+++ b/10_electric/91_en_60617/en_60617_08/en_60617_08_09/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="E">
     <names>
         <name lang="cs">09- Smíšené měřicí články a přístroje</name>
         <name lang="de">09- Sonstige Messgeber und Messgeräte</name>

--- a/10_electric/91_en_60617/en_60617_08/en_60617_08_10/qet_directory
+++ b/10_electric/91_en_60617/en_60617_08/en_60617_08_10/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="E">
     <names>
         <name lang="cs">10- Zdroje světla a signalizační zařízení</name>
         <name lang="de">10- Leuchtmelder und Signaleinrichtungen</name>

--- a/10_electric/91_en_60617/en_60617_11/en_60617_11_03/qet_directory
+++ b/10_electric/91_en_60617/en_60617_11/en_60617_11_03/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="W">
     <names>
         <name lang="cs">03- Vedení</name>
         <name lang="de">03- Leiter, Leitungen</name>

--- a/10_electric/91_en_60617/en_60617_11/en_60617_11_04/qet_directory
+++ b/10_electric/91_en_60617/en_60617_11/en_60617_11_04/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="N">
     <names>
         <name lang="cs">04- Různé</name>
         <name lang="de">04- Verschiedenes</name>

--- a/10_electric/91_en_60617/en_60617_11/en_60617_11_05/qet_directory
+++ b/10_electric/91_en_60617/en_60617_11/en_60617_11_05/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="B">
     <names>
         <name lang="cs">05- Zařízení příjmu</name>
         <name lang="de">05- Kabelköpfe</name>

--- a/10_electric/91_en_60617/en_60617_11/en_60617_11_06/qet_directory
+++ b/10_electric/91_en_60617/en_60617_11/en_60617_11_06/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">06- Zesilovače</name>
         <name lang="de">06- Verstärker</name>

--- a/10_electric/91_en_60617/en_60617_11/en_60617_11_08/qet_directory
+++ b/10_electric/91_en_60617/en_60617_11/en_60617_11_08/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">08- Krabice pro účastnické odbočky a výstupy</name>
         <name lang="de">08- Dosen</name>

--- a/10_electric/91_en_60617/en_60617_11/en_60617_11_10/qet_directory
+++ b/10_electric/91_en_60617/en_60617_11/en_60617_11_10/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="G">
     <names>
         <name lang="cs">10- Silové napáječe</name>
         <name lang="de">10- Fern-Stromversorgungen</name>

--- a/10_electric/91_en_60617/en_60617_11/en_60617_11_12/qet_directory
+++ b/10_electric/91_en_60617/en_60617_11/en_60617_11_12/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="W">
     <names>
         <name lang="cs">12- Elektrická instalace</name>
         <name lang="de">12- Einspeisungen</name>

--- a/10_electric/91_en_60617/en_60617_11/en_60617_11_13/qet_directory
+++ b/10_electric/91_en_60617/en_60617_11/en_60617_11_13/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="X">
     <names>
         <name lang="cs">13- Zásuvky</name>
         <name lang="de">13- Steckdosen</name>

--- a/10_electric/91_en_60617/en_60617_11/en_60617_11_14/qet_directory
+++ b/10_electric/91_en_60617/en_60617_11/en_60617_11_14/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="cs">14- Spínače</name>
         <name lang="de">14- Schalter</name>

--- a/10_electric/91_en_60617/en_60617_11/en_60617_11_15/qet_directory
+++ b/10_electric/91_en_60617/en_60617_11/en_60617_11_15/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="E">
     <names>
         <name lang="cs">15- Světelné vývody a jejich zařízení</name>
         <name lang="de">15- Auslässe und Installationen für Leuchten</name>

--- a/10_electric/91_en_60617/en_60617_11/en_60617_11_16/qet_directory
+++ b/10_electric/91_en_60617/en_60617_11/en_60617_11_16/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="E">
     <names>
         <name lang="cs">16- Různá elektrická zařízení</name>
         <name lang="de">16- Verschiedene Geräte</name>

--- a/10_electric/91_en_60617/en_60617_11/en_60617_11_17/qet_directory
+++ b/10_electric/91_en_60617/en_60617_11/en_60617_11_17/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="N">
     <names>
         <name lang="cs">17- Nosné systémy</name>
         <name lang="de">17- Fertigteile für Kabel-Verteilsysteme</name>

--- a/10_electric/91_en_60617/en_60617_11/en_60617_11_18/qet_directory
+++ b/10_electric/91_en_60617/en_60617_11/en_60617_11_18/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="E">
     <names>
         <name lang="cs">18- Letištní navigační světelná návěstidla a návěstní znaky</name>
         <name lang="de">18- Flugplatzbefeuerung und Anzeiger</name>

--- a/10_electric/98_graphics/01_auxiliary_symbols/01_cross_ref_symbols/01_with_linking_function/01_parents/qet_directory
+++ b/10_electric/98_graphics/01_auxiliary_symbols/01_cross_ref_symbols/01_with_linking_function/01_parents/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Rodiče</name>
         <name lang="de">Eltern</name>

--- a/10_electric/98_graphics/01_auxiliary_symbols/01_cross_ref_symbols/01_with_linking_function/02_children/qet_directory
+++ b/10_electric/98_graphics/01_auxiliary_symbols/01_cross_ref_symbols/01_with_linking_function/02_children/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Potomci</name>
         <name lang="de">Kinder</name>

--- a/10_electric/98_graphics/01_auxiliary_symbols/01_cross_ref_symbols/02_without_linking_function/qet_directory
+++ b/10_electric/98_graphics/01_auxiliary_symbols/01_cross_ref_symbols/02_without_linking_function/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Bez odkazovací funkce (ručně)</name>
         <name lang="de">Ohne Verweisfunktion (manuell)</name>

--- a/10_electric/98_graphics/01_auxiliary_symbols/20_switch_positions/qet_directory
+++ b/10_electric/98_graphics/01_auxiliary_symbols/20_switch_positions/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="S">
     <names>
         <name lang="cs">Polohy přepínačů</name>
         <name lang="de">Schaltstellungen für Wahlschalter</name>

--- a/10_electric/98_graphics/21_forms_tabs/qet_directory
+++ b/10_electric/98_graphics/21_forms_tabs/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="N">
     <names>
         <name lang="cs">Formuláře a tabulky</name>
         <name lang="de">Formulare und Tabellen</name>

--- a/10_electric/99_miscellaneous_unsorted/qet_directory
+++ b/10_electric/99_miscellaneous_unsorted/qet_directory
@@ -1,4 +1,4 @@
-<qet-directory>
+<qet-directory designation-letter="K">
     <names>
         <name lang="cs">Různé</name>
         <name lang="da">Diverse og ikke kategoriseret</name>


### PR DESCRIPTION
## Summary

First real classification data for the mechanism landed in `qelectrotech-source-mirror#668` (see discussion `qelectrotech-source-mirror#666`): an element with no numbering formula and no manual label shows a live `K?`-style placeholder derived from its category's `designation-letter` attribute. Until now nothing set that attribute anywhere, so the mechanism had no data to read. This PR seeds it on **482 of the ~810 category folders** under `10_electric` — every category with at least one classified element, short of two specific exclusions (below) — covering roughly 4900 of 6931 elements directly.

## How categories were chosen

Produced by `tools/iec81346/seed_categories.py` in the `qelectrotech-docker` harness repo, from a classification pass (`classify.py`) over all 6931 elements here. Elements in a category independently classified by name, folder path, or translated `qet_directory` text (not by same-folder majority vote, which is itself already an inference — counting it here would be circular) "vote" on a class; the plurality winner becomes the category's letter.

Three commits, progressively wider:

1. **291 categories**: ≥3 voters, ≥80% agreement (mirrors `classify.py`'s own folder-majority-vote thresholds).
2. **+41 categories**: ≥2 voters, unanimous agreement.
3. **+150 categories**: any category with ≥1 voter at all, ties included.

The first two rounds were deliberately conservative and individually reviewed (see below) before deciding to widen further. Coverage over precision was an explicit choice, not a default — an occasional wrong letter matters much less here than getting stuck maximizing confidence on a project like this one.

Two exclusions apply regardless of confidence, because they're not a precision problem — no amount of accepted imprecision fixes either:

- `98_graphics/99_assembly_plan`: a known-heterogeneous subtree that mixes device kinds by design (a mounting-plate-thumbnail bucket with a PLC, a drive, and disconnect switches all as simplified panel icons).
- `10_allpole/100_folio_referencing`: not a device category at all. Its two elements are cross-page continuation arrows ("Multi wire cable next folio horizontal"), which matched "wire" and agreed unanimously on `W` (guiding object) — evidence strength was never the problem there, the category itself is diagram annotation, not devices.

Every changed file is a **one-line diff**: only the `designation-letter` attribute is added to the existing `<qet-directory>` root tag. Translated `<names>` entries are untouched. Categories with no `qet_directory` file at all were skipped rather than inventing one with an empty `<names>` block — QET's category lookup walks up to the nearest ancestor with a letter set, so an unseeded leaf folder can still inherit one from a parent category; it doesn't need its own entry to benefit.

## Known rough edges

The first two (conservative) rounds were checked category-by-category against actual element names before writing — a 25-category random sample plus every threshold-boundary case for round 1, all 41 categories individually for round 2. The third round (150 categories, deliberately widened past the point where individual review is practical) got a lighter pass: scanned for further instances of the *conceptual* problem found in round 2 (a category that isn't a device category at all), found none, but did not re-verify every individual classification's precision the same way. Expect some debatable or outright wrong letters in there, especially anywhere a tie was involved (Python's `Counter` breaks a 50/50 tie by first-seen order, not by any real signal) — that's the accepted tradeoff for this round, not an oversight.

Two specific things found and worth reviewer attention regardless of round:

- `20_manufacturers_articles/pinball/williams_em/switches_score_motor` seeded `M` (driving object) — every element there is literally named "Switch on Score Motor (...)"; the folder-path fallback picked up "motor" once the element-name match correctly stopped treating "switch on" as the device-noun "switch" (see the keyword fix in the first commit). Arguably these are switch *contacts* triggered by a motor-driven cam, not motors themselves.
- A handful of `..._power_supply`/`Power_supply` categories landed on `G` (generating object) rather than something like `T` (transforming) — a pre-existing keyword-rule interpretation, not newly introduced by this seeding pass, but worth a reviewer's own judgment call.

## Test plan

- Full diff reviewed after each of the 3 commits: 291/41/150 files changed, each with exactly that many insertions and deletions — one line each, confirmed via `git diff --shortstat` every time.
- Round 1: 25-category random sample across all 17 letters, plus every threshold-boundary category, checked individually against real element names before writing.
- Round 2: all 41 categories checked individually (small enough to review exhaustively rather than sample).
- Round 3: scanned for categories matching the same *not-a-device* naming pattern that round 2 found (`referenc|legend|arrow|frame|...`); the 2 matches were verified as genuine relay/breaker contact-symbol folders, not annotation.
- Found and fixed a real false-positive in the underlying keyword rules during round 1 (`switch` matching inside `switch-on`/`switch-off` compound phrasing) before it could seed a wrong letter.
- Found and rejected a single-voter confidence tier during round 2 review after a concrete bad example (`allen_bradley` would have been seeded from one unrepresentative element while its other, unmatched catalog entries are mostly PLCs) — round 3 reintroduces single-voter categories deliberately, per the coverage-over-precision decision above, not because that finding stopped being true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)