### PR TITLE
Add designation prefixes for eight categories in the core symbol trees

### DIFF
--- a/10_electric/qet_labels.xml
+++ b/10_electric/qet_labels.xml
@@ -25,7 +25,9 @@
     <category name="100_sheet_referencing"></category>
     <category name="110_network_supplies"></category>
     <category name="114_connections"></category>
-    <category name="120_cables_wiring"></category>
+    <category name="120_cables_wiring">
+      <prefix>W</prefix>
+    </category>
     <category name="130_terminals_terminal_strips">
       <category name="90_terminal_strips_diagram"></category>
       <prefix>X</prefix>
@@ -163,6 +165,7 @@
       <category name="70_voltage_current_sources">
         <prefix>B</prefix>
       </category>
+      <prefix>B</prefix>
     </category>
     <category name="395_electronics_semiconductors">
       <category name="01_resistors">
@@ -178,11 +181,17 @@
       <category name="11_diodes">
         <prefix>V</prefix>
       </category>
-      <category name="12_transistors"></category>
-      <category name="13_thyristors"></category>
+      <category name="12_transistors">
+        <prefix>V</prefix>
+      </category>
+      <category name="13_thyristors">
+        <prefix>V</prefix>
+      </category>
       <category name="24piezo"></category>
       <category name="31_integrated_circuits"></category>
-      <category name="41_PLC_controllers"></category>
+      <category name="41_PLC_controllers">
+        <prefix>K</prefix>
+      </category>
       <category name="91_computer_science"></category>
     </category>
     <category name="450_high_voltage"></category>
@@ -223,9 +232,11 @@
       <category name="10_converters">
         <prefix>T</prefix>
       </category>
+      <prefix>T</prefix>
     </category>
     <category name="392_generators_sources">
       <category name="10_generators"></category>
+      <prefix>B</prefix>
     </category>
     <category name="395_electronics_semiconductors">
       <category name="10_resistors">
@@ -241,7 +252,9 @@
     <category name="500_home_installation">
       <category name="20_home_appliances"></category>
       <category name="30_architectural"></category>
-      <category name="40_meters"></category>
+      <category name="40_meters">
+        <prefix>P</prefix>
+      </category>
     </category>
   </category>
   <category name="20_manufacturers_articles">


### PR DESCRIPTION
Fills in `<prefix>` for eight categories in `10_allpole` and `11_singlepole` that didn't have one, so elements in them pick up a designation letter via `%prefix` instead of coming out unlabelled.

This is the first, deliberately small batch of a larger effort, following on from [#69](https://github.com/qelectrotech/qelectrotech-elements/pull/69) — which I closed after @scorpio810 pointed out it duplicated this file rather than extending it. Everything here goes into `qet_labels.xml` itself.

## What's added

| category | prefix | why |
|---|---|---|
| `10_allpole/120_cables_wiring` | `W` | cabling |
| `10_allpole/392_generators_sources` | `B` | matches its own child `70_voltage_current_sources` |
| `10_allpole/.../12_transistors` | `V` | matches sibling `11_diodes` |
| `10_allpole/.../13_thyristors` | `V` | matches sibling `11_diodes` |
| `10_allpole/.../41_PLC_controllers` | `K` | matches `01_coils` |
| `11_singlepole/340_converters_inverters` | `T` | matches its own child `10_converters` |
| `11_singlepole/392_generators_sources` | `B` | matches the `10_allpole` equivalent |
| `11_singlepole/500_home_installation/40_meters` | `P` | matches `390_sensors_instruments` |

Every letter follows a convention already established elsewhere in this file rather than introducing anything new.

Three of them are container categories whose children all want the same letter, so the prefix goes on the parent and inheritance covers the rest — the way most of this file is already written.

## Safety

- **No existing prefix is changed**, and **no category that already resolved to a prefix resolves differently.** Verified by expanding the inherit-from-parent rule across the whole file before and after and diffing the result, not just by eyeballing.
- Effective coverage goes from 71 categories to 82.
- The five one-line `<category .../></category>` entries become three lines only because they now have a child; no content is removed.
- `<prefix>` is placed after child `<category>` elements, per this file's own header comment.

## How these were chosen

Machine-proposed, then reviewed by hand — I'm not claiming domain authority here, so the tooling is calibrated against *your* data rather than against an outside standard.

The 50 existing entries expand via inheritance to 71 categories with a known-correct answer, which makes a usable test set. The classifier scores **71/71 against it with no contradictions**; a proposal is only made where the evidence is unambiguous, and categories with mixed or unclear content are deliberately skipped rather than guessed. Notably it does *not* propose anything for containers like `395_electronics_semiconductors`, which holds resistors, capacitors, inductors and diodes — those are correctly left blank so their children keep their own letters.

Worth stating plainly: that 71/71 is measured on data the rules were tuned against, so it's a regression check rather than proof of accuracy. The eight entries above were each checked individually.

Tooling lives in a separate harness repo, not here. Happy to adjust any of these letters — the point of keeping the batch small is to get the convention right before proposing more. Later batches would cover the manufacturer trees, where I'd want more review, not less.
