### PR TITLE
Fix five malformed Catalan names that break XML parsing (one crashes QET)

### DIFF
--- a/10_electric/20_manufacturers_articles/johnson_controls/dx/modules_extension/xpx.elmt
+++ b/10_electric/20_manufacturers_articles/johnson_controls/dx/modules_extension/xpx.elmt
@@ -1,7 +1,7 @@
 <definition version="0.100.0" type="element" link_type="simple" width="140" height="220" hotspot_x="25" hotspot_y="25">
     <uuid uuid="{ec0beb90-fa75-2fc7-a562-1615cd457f79}"/>
     <names>
-        <name lang="ca">Unitat xPx &#11;erge</name>
+        <name lang="ca">Unitat xPx verge</name>
         <name lang="cs">Modul XPx (neoznačený)</name>
         <name lang="en">Unit xPx "virgin"</name>
         <name lang="es">Modulo XPx "virgen"</name>

--- a/10_electric/91_en_60617/en_60617_06/en_60617_06_04/en_60617_06_04_01.elmt
+++ b/10_electric/91_en_60617/en_60617_06/en_60617_06_04/en_60617_06_04_01.elmt
@@ -1,7 +1,7 @@
 <definition version="0.100.0" type="element" link_type="simple" width="70" height="70" hotspot_x="65" hotspot_y="65">
     <uuid uuid="{c8308dfd-83c1-fed8-0e20-412fde96dde6}"/>
     <names>
-          <name lang="ca">Màquina, símbol general (substituir "*" per designació):
+          <name lang="ca">Màquina, símbol general (substituir "*" per designació):</name>
         <name lang="cs">Stroj, všeobecná značka:
 C rotační měnič
 G generátor

--- a/60_energy/11_water/01_Termicas-Fluidos2_Rafa/Flechas/persona-alzado.elmt
+++ b/60_energy/11_water/01_Termicas-Fluidos2_Rafa/Flechas/persona-alzado.elmt
@@ -1,7 +1,7 @@
 <definition version="0.100.0" type="element" link_type="simple" width="50" height="90" hotspot_x="31" hotspot_y="60">
     <uuid uuid="{d6f1a6d9-6c64-1bb7-10c3-1cce7ef98230}"/>
     <names>
-          <name lang="ca">Persona en alçat/name>
+          <name lang="ca">Persona en alçat</name>
         <name lang="es">Persona en alzado</name>
           <name lang="pt_BR">Persona en alzado</name>
         <name lang="zh">人-正视图</name>

--- a/60_energy/11_water/01_Termicas-Fluidos2_Rafa/Gas/esquemas-gas/gas-calentador-acum.elmt
+++ b/60_energy/11_water/01_Termicas-Fluidos2_Rafa/Gas/esquemas-gas/gas-calentador-acum.elmt
@@ -1,7 +1,7 @@
 <definition version="0.100.0" type="element" link_type="simple" width="40" height="40" hotspot_x="29" hotspot_y="18">
     <uuid uuid="{be9cdd0f-bcea-00ff-cabd-7ec8cfe41519}"/>
     <names>
-          <name lang="ca">Calentador-acumulador d'aigua<</name>
+          <name lang="ca">Calentador-acumulador d'aigua</name>
         <name lang="es">Calentador-acum. agua</name>
           <name lang="pt_BR">Calentadou-acum. agua</name>
         <name lang="zh">燃气储水式热水器</name>

--- a/60_energy/21_refrigeration/Frio/sinopticosfrio/compresseursetventilateurs/comp-alternativo.elmt
+++ b/60_energy/21_refrigeration/Frio/sinopticosfrio/compresseursetventilateurs/comp-alternativo.elmt
@@ -1,7 +1,7 @@
 <definition version="0.100.0" type="element" link_type="simple" width="60" height="50" hotspot_x="46" hotspot_y="25">
     <uuid uuid="{4122d711-6d2e-f0e1-c90a-969b59bc3a3f}"/>
     <names>
-          <name lang="ca">Compressor altern</</name>
+          <name lang="ca">Compressor altern</name>
         <name lang="es">Compr.Altern</name>
           <name lang="pt_BR">Compr.Altern</name>
         <name lang="zh">往复式压缩机</name>


### PR DESCRIPTION
Scanning every `.elmt` in the collection for XML well-formedness turned up **5 malformed files out of 8755**. All five are damage in the `<name lang="ca">` entry, which suggests one bad translation batch rather than five unrelated edits.

| file | defect |
|---|---|
| `comp-alternativo.elmt` | stray `</` inside the text |
| `gas-calentador-acum.elmt` | stray `<` inside the text |
| `persona-alzado.elmt` | closing tag written `/name>` — missing `<` |
| `en_60617_06_04_01.elmt` | no closing `</name>` at all |
| `xpx.elmt` | `&#11;` where the letter `v` belongs |

### Four of them make the element unusable

QET reports an XML error and the symbol simply never loads:

```
FAIL  .../persona-alzado.elmt  (XML error line 8: tag mismatch)
```

### The fifth crashes QElectroTech

`&#11;` is a numeric reference to **U+000B**, which is not a legal character in XML 1.0. Qt's `QDomDocument::setContent()` **segfaults** on it instead of reporting a parse error — confirmed under gdb, with the whole stack inside `libQt5Xml`. A seven-line test file reproduces it: with `&#11;` the process dies with SIGSEGV, change it to `v` and it parses fine.

The practical effect is that `qelectrotech --check-elements` over the collection dies partway through, and any other code path that parses that file inherits the crash.

The neighbouring translations read "virgin" (en), "virgen" (es), "vierge" (fr) and "vergine" (it), so the Catalan was meant to be **"Unitat xPx verge"** — the `v` has simply been replaced by `&#11;`. Restored.

### Scope

Only the malformed markup is touched. No wording is changed, and nothing outside the five `<name lang="ca">` lines is modified — five files, one line each.

### Verification

- All **8755** `.elmt` files in the repository now parse (checked with a standalone XML parser, independent of Qt).
- `qelectrotech --check-elements` over the whole tree now completes: **8755 file(s), 0 failure(s)**, where it previously terminated with SIGSEGV.

Worth noting separately: Qt crashing rather than erroring on an illegal character reference means a hand-edited or corrupted `.elmt` can take the application down. That's a robustness question for the main repo rather than something to fix here, but it's the reason this particular typo mattered.