### PR TITLE
Fix German and French names of "Device (connection on top)"

### DIFF
--- a/10_electric/10_allpole/130_terminals_terminal_strips/90_terminal_strips_diagram/90-20-0002.elmt
+++ b/10_electric/10_allpole/130_terminals_terminal_strips/90_terminal_strips_diagram/90-20-0002.elmt
@@ -3,10 +3,10 @@
     <names>
         <name lang="ca">Dispositiu (connexió a la part superior)</name>
         <name lang="cs">Zařízení (připojení shora)</name>
-        <name lang="de">Gerät (Anschluss unten)</name>
+        <name lang="de">Gerät (Anschluss oben)</name>
         <name lang="en">Device (connection on top)</name>
         <name lang="es">Dispositivo (conexión por encima)</name>
-        <name lang="fr">Appareil (connexion en bas)</name>
+        <name lang="fr">Appareil (connexion en haut)</name>
         <name lang="hu">Eszköz (felső csatlakozás)</name>
         <name lang="it">Dispositivo (connessione in alto)</name>
         <name lang="pt_BR">Dispositivo com conexão superior</name>


### PR DESCRIPTION
The element 90-20-0002 has its terminal on top (terminal at y=-4, orientation north), and the English, Spanish, Catalan, Czech, Hungarian and Italian names all say so — but the German name said "Anschluss unten" and the French one "connexion en bas" (both meaning connection at the bottom). This aligns them with the actual geometry: "Anschluss oben" / "connexion en haut".
